### PR TITLE
fix(dashboard): replace setInterval with recursive setTimeout, add visibilitychange (D12)

### DIFF
--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -82,13 +82,21 @@ body{font-family:system-ui,-apple-system,sans-serif;background:#0f1117;color:#e1
 <div class="panel" id="panel-alerts"><div class="card"><h2>Emergency Alerts</h2><p>No alerts.</p></div></div>
 </div>
 <script>
+let activeTab='overview';
+let pageVisible=!document.hidden;
+let failCount=0;
 document.querySelectorAll('.tab').forEach(t=>{
   t.addEventListener('click',()=>{
     document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
     document.querySelectorAll('.panel').forEach(x=>x.classList.remove('active'));
     t.classList.add('active');
     document.getElementById('panel-'+t.dataset.tab).classList.add('active');
+    activeTab=t.dataset.tab;
   });
+});
+document.addEventListener('visibilitychange',()=>{
+  pageVisible=!document.hidden;
+  if(pageVisible){poll();}
 });
 async function poll(){
   try{
@@ -101,21 +109,29 @@ async function poll(){
     const badge=document.getElementById('mode-badge');
     badge.textContent=s.mode.replace('_',' ');
     badge.className='mode-badge mode-'+s.mode.split('_')[0];
-  }catch(e){}
-  try{
-    const e=await(await fetch('/dashboard/api/evidence')).json();
-    document.getElementById('evidence-info').textContent=
-      'Chain head: seq '+e.chain_head_seq+' | Total: '+e.total_receipts+' receipts';
-  }catch(e){}
-  try{
-    const m=await(await fetch('/dashboard/api/memory')).json();
-    document.getElementById('memory-info').textContent=
-      'Tracked: '+m.tracked_files+' files | Changes: '+m.changes_detected+
-      ' | Unacknowledged: '+m.unacknowledged_changes;
-  }catch(e){}
+    failCount=0;
+  }catch(e){
+    if(++failCount>=5)document.getElementById('stat-health').textContent='Disconnected';
+  }
+  if(!pageVisible)return;
+  if(activeTab==='evidence'||activeTab==='overview'){
+    try{
+      const e=await(await fetch('/dashboard/api/evidence')).json();
+      document.getElementById('evidence-info').textContent=
+        'Chain head: seq '+e.chain_head_seq+' | Total: '+e.total_receipts+' receipts';
+    }catch(e){}
+  }
+  if(activeTab==='memory'||activeTab==='overview'){
+    try{
+      const m=await(await fetch('/dashboard/api/memory')).json();
+      document.getElementById('memory-info').textContent=
+        'Tracked: '+m.tracked_files+' files | Changes: '+m.changes_detected+
+        ' | Unacknowledged: '+m.unacknowledged_changes;
+    }catch(e){}
+  }
 }
-poll();
-setInterval(poll,2000);
+function schedule(){poll().finally(()=>setTimeout(schedule,2000));}
+schedule();
 </script>
 </body>
 </html>"#;


### PR DESCRIPTION
## What changed

Three surgical changes to the `<script>` block in `adapter/aegis-dashboard/src/assets.rs`. No HTML, no CSS, no Rust touched.

---

## Why this was broken

### Bug 1 — `setInterval` causes request pileup

The current implementation runs all fetch calls inside `setInterval(poll, 2000)`. `setInterval` fires on a fixed clock regardless of whether the previous call finished. If the adapter is slow or under load — exactly the situation during an active attack — the 2s interval fires before the previous fetch returned. Requests stack up. Responses arrive out of order. The UI shows stale or inconsistent data at the moment it matters most.

`setInterval` is the wrong tool for API polling. The established best practice is recursive `setTimeout`: schedule the next poll only after the current one completes. This guarantees a minimum gap between requests and makes the polling rate self-regulating under load.

**Fix:** `setInterval(poll, 2000)` → `function schedule(){poll().finally(()=>setTimeout(schedule,2000));} schedule();`

---

### Bug 2 — Silent `catch(e){}` hides adapter disconnection

All three fetch calls in the original `poll()` swallow errors silently. If the adapter process dies, the dashboard continues showing the last known values — "Healthy", with whatever receipt count was last fetched — with no indication that the data is stale or that the adapter is unreachable. A warden watching the dashboard during an incident would see no signal that monitoring had stopped.

**Fix:** The status fetch now increments `failCount` on each failure. After 5 consecutive failures (~10 seconds), the health field shows `Disconnected` instead of the last cached value. On the next successful fetch `failCount` resets and the real value returns.

---

### Bug 3 — All endpoints polled every 2s regardless of active tab

Evidence and memory data are fetched on every poll cycle even when the warden is on the Alerts tab and those panels are not visible. At 6 endpoints × 2s this is unnecessary network traffic to a localhost server, and it becomes meaningless work when most panels are not being viewed.

**Fix:** Evidence and memory fetches are now guarded by `activeTab`. They only run when the relevant panel is active (or when on Overview, which shows summary data from both). The tab click handler now tracks `activeTab` as a module-level variable.

---

### Bug 4 — No `visibilitychange` handling

The original implementation polls blindly whether or not the warden is looking at the dashboard. When the warden switches to another browser tab, Chrome immediately throttles `setTimeout`/`setInterval` to fire at most once per second. After 5 minutes in the background, Chrome throttles further to once per minute. The dashboard has no awareness of this — it schedules at 2s and Chrome silently stretches that to 60s.

This is not a correctness problem for Aegis specifically — the adapter binary runs continuously in Rust and stores all events server-side regardless of what the browser is doing. The dashboard is a display, not the monitoring system. Alerts are never lost because the browser throttled.

However, the original implementation also does not fetch immediately when the warden returns to the tab. The warden switches back, and then waits up to 2s (or up to 60s if Chrome had already throttled) before the UI refreshes. During an active incident that delay is noticeable.

The Page Visibility API's MDN documentation explicitly lists dashboards as the canonical use case: *"An application showing a dashboard of information doesn't want to poll the server for updates when the page isn't visible."*

**Fix:** A `visibilitychange` listener sets `pageVisible`. The `poll()` function returns early after the status fetch when `pageVisible` is false, skipping evidence and memory requests. When the warden returns to the tab, `poll()` fires immediately — they get fresh data instantly, not after waiting for the next scheduled tick.

---

## What was not changed

- Polling interval remains 2s — confirmed correct for D12
- WebSocket and SSE remain excluded — decision unchanged
- No HTML or CSS modified — total size impact is ~+676 bytes
- No Rust routes modified — all API endpoints unchanged
- The 50KB size budget is not affected