### PR TITLE
docs(D3v3): narrow internal NATS scope — embedding uses load balancer…

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -139,6 +139,31 @@ Common fields (all claim types):
 
 ---
 
+### D3: Adapter ↔ Cluster Communication — v3 Addendum
+**Status: LOCKED (v3 — addendum to existing v2 lock)**
+
+v2 established: adapter uses HTTPS+WSS, NATS is internal only.
+v3 addendum narrows NATS scope further — even internally:
+
+| Embedding path | Transport | NATS? | Why |
+|---|---|---|---|
+| RAG query — embed question | Local in-process call, Node 3 | No | D35 co-location. RAG and GPU B same process. ~2ms. |
+| POST /embedding from bot | Load balancer at Gateway → GPU A or B | No | Option B GPUs dedicated to embedding. No GPU-state needed. Simple least-connections. |
+| Botawiki write — index claim | NATS async botawiki.embed | Yes | Bot is done. Background side effect. No user waiting. Retry on failure via JetStream. |
+| Centaur query | NATS → GPU Scheduler → Centaur node | Yes | Queue management, TRUSTMARK priority, credit check at entry. Async result push via WSS. |
+
+Principle locked: NATS is used only where work is genuinely async
+(bot has moved on, no user is waiting). Synchronous paths where a
+bot is waiting use direct HTTP + load balancer at the Gateway.
+
+Option C note: when active T3 bots exceed 150 and Option C is
+enabled (Centaur added to Nodes 1+3), the GPU Scheduler is also
+used for embedding routing — because GPU-busy state on Nodes 1+3
+must be checked before sending an embedding call there. This is
+a config change (config.toml + SIGHUP), not a code change.
+
+---
+
 ### D4: SLM Structured Output Schema (was "Wire Format") 🔒
 
 **Status:** LOCKED — Applied to `adapter/aegis-slm/src/{types.rs, scoring.rs, parser.rs, holster.rs}`
@@ -1047,7 +1072,7 @@ If the adapter reports which non-standard files appear across multiple warden wo
 | D0  | 0 | BIP-39 → SLIP-0010 → Ed25519 (path 784') | 🔒 LOCKED |
 | D1  | 0 | Evidence receipt: ReceiptCore + ReceiptContext split | 🔒 LOCKED |
 | D2  | 0 | Wire format: RFC 8785 JCS, lowercase hex, basis points | 🔒 LOCKED |
-| D3  | 0 | Adapter↔Cluster: NC-Ed25519 auth, HTTPS+WSS | 🔒 LOCKED |
+| D3  | 0 | Transport: HTTPS+WSS adapter, NATS internal only. v3: NATS scope narrowed — embedding uses load balancer or local call, not NATS Scheduler | 🔒 LOCKED (v3) |
 | D4  | 0 | SLM: 3-way separation, 14 patterns, scoring_v1 | 🔒 LOCKED |
 | D5  | 0 | Write barrier: triple-layer, WriteToken, HashRegistry | 🔒 LOCKED |
 | D6  | 1 | SLM structured output (absorbed into D4) | 🔒 LOCKED |

--- a/NC_Decision_Log.md
+++ b/NC_Decision_Log.md
@@ -1,0 +1,51 @@
+# Neural Commons — Decision Log
+
+Chronological log of decision amendments and addenda.
+
+---
+
+### D3 v3 Addendum: Internal NATS Scope
+**Status: LOCKED (extends v2)**
+**Locked:** 2026-03-08
+
+v2 established adapter transport (HTTPS+WSS, no NATS on client).
+v3 narrows internal NATS usage after embedding pipeline analysis.
+
+Finding: the GPU Scheduler was over-specified as the router for
+direct embedding calls. This introduced NATS into a synchronous
+user-facing path where a simple load balancer is sufficient and
+significantly simpler to debug.
+
+Three embedding scenarios analysed:
+
+1. RAG query — embed the question before pgvector search
+   Transport: local in-process call (Node 3, same process as pgvector)
+   NATS: No
+   Reason: D35 co-locates RAG Service + Embedding GPU B + pgvector
+   on Node 3. Zero network hop. ~2ms. No routing needed.
+
+2. Direct POST /embedding from bot adapter
+   Transport: Gateway → HTTP → least-connections load balancer
+              → Embedding Service on Node 1 or Node 3
+   NATS: No (Option B) / Yes via Scheduler (Option C only)
+   Reason: In Option B, Nodes 1+3 are dedicated embedding nodes.
+   No GPU-state awareness needed. Round-robin/least-connections
+   is sufficient. NATS + Scheduler added async complexity to a
+   synchronous path with no benefit in Option B.
+
+3. Botawiki write — background vector indexing
+   Transport: NATS async, subject botawiki.embed
+   NATS: Yes — correct and intentional
+   Reason: Bot is done, has received ACK, has moved on. Embedding
+   is a background side effect with no user waiting. Retry on
+   failure via JetStream. This is the one genuine async case.
+
+Principle: NATS is correct when work is genuinely async (no user
+waiting, retry semantics needed). Direct HTTP + load balancer is
+correct when a user is waiting synchronously.
+
+Consequence for D24/D19:
+  Rate limit counter and credit counter both tick only at the
+  Gateway. Internal calls (RAG local embed, Botawiki async embed)
+  never reach the Gateway and are invisible to both systems.
+  The double-count problem is structurally eliminated.

--- a/NC_System_Architecture.md
+++ b/NC_System_Architecture.md
@@ -1,0 +1,28 @@
+# Neural Commons — System Architecture
+
+## NATS Topic Topology
+
+| Stream | Subjects | Publishers | Subscribers | Retention | Note |
+|---|---|---|---|---|---|
+| EVIDENCE | evidence.new, evidence.rollup | Evidence Ingestion | TRUSTMARK Engine, archiver | File, 30 days | |
+| TRUSTMARK | trustmark.updated | TRUSTMARK Engine | Gateway cache, tier-gate | File, 7 days | |
+| BOTAWIKI | botawiki.claim.new, botawiki.quarantine.vote, botawiki.dispute.new, botawiki.embed | Botawiki Service | quarantine-validator, dispute-handler, embed-indexer | File, 90 days | botawiki.embed is the async background indexing subject — Embedding Service Node 3 consumes it |
+| MESH | mesh.relay, mesh.key.update | Mesh Relay | mesh-router, key-directory | Memory, 72h | Dead-drops go to MinIO (Node 5), not this stream |
+| SCHEDULER | scheduler.request, scheduler.assigned, scheduler.heartbeat, scheduler.completed | GPU Scheduler | Centaur nodes (2, 4, 5) | Memory, WorkQueue | Option B: Centaur only. Direct embedding uses Gateway load balancer — NOT this stream. Option C: embedding added here when Nodes 1+3 also run Centaur. |
+| BROADCAST | broadcast.emergency, broadcast.policy | Policy Distribution | All connected adapters via Gateway WSS | File, 365 days | |
+
+### Embedding Routing — Three Scenarios (D3 v3 + D35)
+
+| Scenario | Transport | NATS? | Latency | Rate limit ticks? |
+|---|---|---|---|---|
+| RAG — embed the question | Local call, Node 3 in-process | No | ~2ms | No (internal) |
+| POST /embedding from bot | Gateway load balancer → Node 1 or 3 | No | ~15ms | Yes — embedding counter +1 |
+| Botawiki write — index claim | NATS async botawiki.embed → Node 3 | Yes | seconds (background) | No (internal) |
+
+Principle: NATS is used only where work is genuinely async. The
+load balancer at the Gateway handles direct embedding — round-robin
+or least-connections across Nodes 1 and 3.
+
+Option C: when Centaur is added to Nodes 1+3 (escalation config),
+the GPU Scheduler is also used for embedding routing. Config change,
+not code change.

--- a/cluster/scheduler/src/lib.rs
+++ b/cluster/scheduler/src/lib.rs
@@ -1,8 +1,25 @@
-//! aegis-scheduler: GPU scheduler
+//! GPU Scheduler — Centaur inference orchestration (Rust)
 //!
-//! Model registry, request router across GPU nodes
-//! Centaur on-demand loading: cold start <30s, hot-pin at >50 daily queries (D27)
-//! Phase 4 only
+//! SCOPE IN OPTION B (Phase 3 launch config):
+//!   Handles CENTAUR REQUESTS ONLY via NATS scheduler.* subjects.
+//!   Direct embedding calls (POST /embedding) bypass this scheduler
+//!   entirely — they are load-balanced at the Edge Gateway.
+//!   RAG embedding is a local call on Node 3 — never reaches here.
+//!
+//! SCOPE IN OPTION C (escalation — config change only):
+//!   When Centaur is added to Nodes 1+3, this scheduler also handles
+//!   embedding routing with GPU-busy awareness. Enable by editing
+//!   cluster/scheduler/config.toml and sending SIGHUP.
+//!   No code change required for Option B → C transition.
+//!
+//! Routing algorithm (Centaur, both options):
+//!   1. Tier check — Centaur from T1/T2 → 403 TierInsufficient
+//!   2. Credit check at queue ENTRY — balance ≤ 0 → 402
+//!   3. Global queue cap = 50 — depth ≥ 50 → 503 QueueFull
+//!   4. Route to shortest queue among active Centaur nodes
+//!   5. TRUSTMARK score breaks ties (higher score = shorter wait)
+//!
+//! Hot-pin threshold: D27 (pending — stubbed in config.toml)
 
 pub mod registry;
 pub mod router;

--- a/infra/nats/NATS_TOPOLOGY.md
+++ b/infra/nats/NATS_TOPOLOGY.md
@@ -23,12 +23,18 @@ Layer 2 tests implement this document.
   - `tier-gate` (push, ack-explicit, max-deliver 3) — evaluate tier transitions
 
 ### `BOTAWIKI` Stream
-- **Subjects:** `botawiki.claim.new`, `botawiki.quarantine.vote`, `botawiki.dispute.new`
+- **Subjects:** `botawiki.claim.new`, `botawiki.quarantine.vote`, `botawiki.dispute.new`, `botawiki.embed`
 - **Storage:** File
 - **Retention:** Limits (max 5GB, max 90 days)
 - **Consumers:**
   - `quarantine-validator` (push, ack-explicit, max-deliver 3) — trigger validation
   - `dispute-handler` (push, ack-explicit, max-deliver 5) — handle disputes
+  - `embed-indexer` (push, ack-explicit, max-deliver 3) — consumes
+    botawiki.embed subject. Runs on Node 3. Calls Embedding Service B
+    locally to build pgvector index for the new claim.
+    Storage: Memory (background job, no persistence needed — if
+    Node 3 restarts, Botawiki Service republishes unindexed claims
+    on startup via a reconciliation query).
 
 ### `MESH` Stream
 - **Subjects:** `mesh.relay`, `mesh.key.update`
@@ -39,11 +45,26 @@ Layer 2 tests implement this document.
   - `key-directory` (push, ack-explicit, max-deliver 3) — update key directory
 
 ### `SCHEDULER` Stream
-- **Subjects:** `scheduler.request`, `scheduler.assigned`
+- **Subjects:** `scheduler.request`, `scheduler.assigned`,
+                `scheduler.heartbeat`, `scheduler.completed`
 - **Storage:** Memory
 - **Retention:** WorkQueue (consumed once)
 - **Consumers:**
-  - `gpu-router` (pull, ack-explicit, max-deliver 1) — assign to GPU node
+  - `gpu-router` (pull, ack-explicit, max-deliver 1) — Centaur only
+
+SCOPE — Option B (Phase 3 launch):
+  This stream handles CENTAUR REQUESTS ONLY.
+  Direct embedding calls (POST /embedding) are NOT routed through
+  this stream — they use a least-connections HTTP load balancer
+  at the Edge Gateway across Nodes 1 and 3.
+  RAG embedding is a local in-process call on Node 3 — no NATS.
+
+SCOPE — Option C (escalation, config change):
+  When Centaur is added to Nodes 1+3 (edit config.toml, SIGHUP),
+  embedding routing is added to this stream. The Scheduler checks
+  GPU-busy state on Nodes 1+3 before routing embedding calls there.
+  Enable by adding "centaur" to node1/node3 model lists in
+  cluster/scheduler/config.toml.
 
 ### `BROADCAST` Stream
 - **Subjects:** `broadcast.emergency`, `broadcast.policy`
@@ -80,10 +101,13 @@ trustmark.query           — request TRUSTMARK for a bot
 botawiki.claim.new        — new claim submitted
 botawiki.quarantine.vote  — validator vote on quarantined claim
 botawiki.dispute.new      — dispute filed against a claim
+botawiki.embed            — background vector indexing of new claims
 mesh.relay                — mesh message relay
 mesh.key.update           — key rotation broadcast
 scheduler.request         — GPU compute request
 scheduler.assigned        — GPU compute assigned
+scheduler.heartbeat       — GPU node heartbeat
+scheduler.completed       — GPU compute completed
 broadcast.emergency       — Foundation emergency broadcast
 broadcast.policy          — Foundation policy distribution
 ```


### PR DESCRIPTION
…, not Scheduler

STEP 2 — D3 v3 addendum: NATS scope is narrower than specced
  D3 was re-locked as v2 (HTTPS+WSS adapter, NATS internal only).
  But after D35, we analysed each embedding scenario separately and
  found NATS was overspecified even internally:

  Scenario A — RAG query embedding:
    RAG Service and Embedding GPU B are on the same Node 3 (D35
    co-location). The embed call is a local in-process function call.
    ~2ms. No NATS. No Scheduler. Nothing to build here.

  Scenario B — Direct POST /embedding from bot:
    OLD SPEC: Gateway → NATS → GPU Scheduler → NATS → GPU A or B
    NEW SPEC: Gateway → load balancer → GPU A (Node 1) or GPU B (Node 3)
    Rationale: In Option B, Nodes 1 and 3 are dedicated to embedding
    only. Nothing else touches their GPUs. A load balancer has zero
    need to know GPU state — it just balances. NATS and the Scheduler
    add async complexity to a path where the bot is waiting
    synchronously. Simple least-connections HTTP load balancer at the
    Gateway is correct. Trivial to debug. No async stack traces.
    The Scheduler only enters embedding routing in Option C, when
    Nodes 1+3 also run Centaur and GPU-busy state must be checked
    before routing. That is a config change, not a code change.

  Scenario C — Botawiki write, background indexing:
    Bot submits write, gets ACK once claim hits PostgreSQL.
    Embedding the claim text for vector search is a background
    side effect — bot has moved on, no user is waiting.
    NATS async is correct and the right tool here. This is the only
    embedding path that genuinely needs NATS.

  The principle established:
    NATS is used only where work is genuinely async — background jobs,
    fan-out, retries, things no user is waiting on.
    Synchronous paths (user waiting for response) use direct HTTP
    + load balancer. Simpler to build, simpler to debug, no async nightmares in production.

STEP 3 — D3 v3 makes the Gateway the correct enforcement point
  Because direct embedding now goes load-balancer at Gateway (not NATS
  to Scheduler), and RAG embedding is a local Node 3 call (not NATS),
  the Gateway is the single and only place where:
    - Rate limits tick (D24)
    - Credit counters tick (D19) Internal service-to-service calls — RAG calling embed locally, Botawiki background indexing — are invisible to both systems. A bot calling POST /rag gets +1 on its RAG counter only, never +1 on its embedding counter. The double-count problem is structurally eliminated, not worked around.

Files:
- DECISIONS.md: D3 quick-reference updated to v3, addendum entry added
- NC_Decision_Log.md: created with D3 v3 chronological entry
- NC_System_Architecture.md: NATS topic table + embedding routing section
- infra/nats/NATS_TOPOLOGY.md: SCHEDULER scope narrowed, botawiki.embed added
- cluster/scheduler/src/lib.rs: doc comment updated with Option B/C scope

https://claude.ai/code/session_01EMPrLgtsWBwNnLQiMivEmu