### PR TITLE
Add Claude Code integration: upgraded CLAUDE.md, custom commands, dogfooding setup

### DIFF
--- a/.claude/commands/adapter-state.md
+++ b/.claude/commands/adapter-state.md
@@ -1,0 +1,89 @@
+# Adapter State Report
+
+Read the adapter configuration and source code to report the current operational state. Do not modify any code.
+
+## What to Report
+
+### 1. Current Mode
+
+Read `adapter/aegis-adapter/src/config.rs` and `adapter/aegis-proxy/src/config.rs` to determine:
+- What is the default mode? (observe_only / enforce / pass_through)
+- What modes are available?
+- How is the mode set? (config file, CLI flag override)
+
+### 2. Protection Enforcement Status (D30)
+
+Read `adapter/aegis-adapter/src/server.rs` (the `create_middleware_hooks` function and enforcement config) to report which protections are active vs warn-only:
+
+Per D30 defaults:
+- `write_barrier` — **observe** by default (warns but does not block)
+- `slm_reject` — **observe** by default (warns but does not block)
+- `vault_block` — **always enforce** (blocks on credential detection)
+- `memory_write` — **always enforce** (blocks on suspicious memory writes)
+
+Check `adapter/aegis-adapter/src/config.rs` for the enforcement config structure and defaults.
+
+### 3. SLM Status
+
+Read `adapter/aegis-slm/src/ollama.rs` and `adapter/aegis-adapter/src/hooks.rs` to report:
+- Is SLM enabled? (check `config.slm.enabled` in server.rs)
+- What Ollama URL is configured? (default: `http://127.0.0.1:11434`)
+- What model is configured? (default: `llama3.2:1b`)
+- Is heuristic fallback enabled? (default: `true`)
+- What happens when `--no-slm` is passed? (check CLI and server.rs)
+
+### 4. Protected Files
+
+Read `adapter/aegis-barrier/src/protected_files.rs` to list all system-protected files:
+- List every pattern in `ProtectedFileManager::new()` system_files
+- For each: pattern, scope (WorkspaceRoot/DepthLimited), critical (yes/no), sensitivity (Standard/Credential)
+- What is the max watched paths cap? (check `MAX_WATCHED_PATHS` in types.rs)
+
+### 5. Config Values in Effect
+
+Read `adapter/aegis-adapter/src/config.rs` and `adapter/aegis-proxy/src/config.rs` to report all default values:
+- Listen address
+- Upstream URL
+- Max body size
+- Rate limit per minute
+- SLM model and URL
+- Memory hash interval
+- Dashboard path
+
+## Output Format
+
+```
+## Aegis Adapter State Report
+
+### Mode
+- Current default: [observe_only/enforce/pass_through]
+- Override: [how to override via CLI]
+
+### Protection Enforcement (D30)
+| Protection    | Default    | Effect                          |
+|---------------|------------|---------------------------------|
+| write_barrier | observe    | Warns on protected file changes |
+| slm_reject    | observe    | Warns on injection detection    |
+| vault_block   | enforce    | Blocks credential leaks         |
+| memory_write  | enforce    | Blocks suspicious memory writes |
+
+### SLM Status
+- Enabled: [yes/no]
+- Ollama URL: [url]
+- Model: [model name]
+- Heuristic fallback: [yes/no]
+- --no-slm behavior: [description]
+
+### Protected Files (System Defaults)
+| Pattern       | Scope          | Critical | Sensitivity |
+|---------------|----------------|----------|-------------|
+| SOUL.md       | WorkspaceRoot  | yes      | Standard    |
+| ...           | ...            | ...      | ...         |
+
+### Config Defaults
+| Key                    | Default Value               |
+|------------------------|-----------------------------|
+| proxy.listen_addr      | 127.0.0.1:3141             |
+| proxy.upstream_url     | https://api.anthropic.com  |
+| ...                    | ...                         |
+```

--- a/.claude/commands/check-wiring.md
+++ b/.claude/commands/check-wiring.md
@@ -1,0 +1,80 @@
+# Check Wiring — Adapter Connection Audit
+
+Audit all 17 connection points in the Aegis adapter. Read the source files and verify each point is correctly wired. Do not modify any code.
+
+## Connection Points to Verify
+
+Read the following source files and check each connection point. Report **PASS** or **FAIL** for each.
+
+### Server Wiring (`adapter/aegis-adapter/src/server.rs`)
+
+1. **Dashboard mounted** — Is `aegis_dashboard::routes::routes(dashboard_state)` called and the result passed to `aegis_proxy::proxy::start()` as the dashboard parameter?
+2. **Upstream default correct** — Is the default upstream URL `https://api.anthropic.com` in `adapter/aegis-proxy/src/config.rs` `ProxyConfig::default()`?
+3. **Memory monitor spawned** — Is there a `tokio::spawn` block that calls `monitor.run()` with `MemoryMonitor::new()`? Is it guarded by `mode != PassThrough`?
+4. **Barrier watcher spawned** — Is there a `tokio::spawn` block with `notify::RecommendedWatcher`? Is it guarded by `mode != PassThrough`?
+5. **Alert broadcast channel created** — Is `tokio::sync::broadcast::channel` called? Is the sender passed to hooks and dashboard state?
+
+### Proxy Wiring (`adapter/aegis-proxy/src/proxy.rs`)
+
+6. **SSE streaming path exists** — Does `forward_request()` check for `Content-Type: text/event-stream` OR `Transfer-Encoding: chunked` and handle streaming separately from buffered responses?
+
+### Hook Wiring (`adapter/aegis-adapter/src/hooks.rs`)
+
+7. **Evidence hook real** — Does `EvidenceHookImpl` call `self.recorder.record_simple()` in both `on_request` and `on_response`?
+8. **SLM hook real** — Does `SlmHookImpl` call `aegis_slm::loopback::screen_content()` via `spawn_blocking`?
+9. **Barrier hook real** — Does `BarrierHookImpl` check `self.protected_files.lock()` and call `self.recorder.record_simple()` for WriteBarrier events?
+10. **Vault hook real** — Does `VaultHookImpl` call `scanner::scan_text()` and return `VaultDecision::Detected` when findings are non-empty?
+
+### Dashboard Wiring (`adapter/aegis-dashboard/src/routes.rs`)
+
+11. **`/api/status` endpoint** — Is there a `GET /api/status` route that returns mode, uptime, receipt_count?
+12. **`/api/evidence` endpoint** — Is there a `GET /api/evidence` route that returns total_receipts, chain_head_seq?
+13. **`/api/memory` endpoint** — Is there a `GET /api/memory` route?
+14. **`/api/vault` endpoint** — Is there a `GET /api/vault` route?
+15. **`/api/access` endpoint** — Is there a `GET /api/access` route?
+16. **`/api/alerts` endpoint** — Is there a `GET /api/alerts` route?
+17. **`/api/alerts/stream` endpoint** — Is there a `GET /api/alerts/stream` SSE route?
+
+### CLI Wiring (`adapter/aegis-cli/src/main.rs`)
+
+18. **`setup openclaw` command exists** — Is there a `setup openclaw` subcommand?
+19. **Vault CLI wired** — Is `aegis vault summary` wired to VaultStorage?
+
+## Output Format
+
+Report as a checklist with a summary score:
+
+```
+## Adapter Wiring Audit
+
+### Server Wiring
+- [ ] 1. Dashboard mounted — PASS/FAIL: [details]
+- [ ] 2. Upstream default correct — PASS/FAIL: [details]
+- [ ] 3. Memory monitor spawned — PASS/FAIL: [details]
+- [ ] 4. Barrier watcher spawned — PASS/FAIL: [details]
+- [ ] 5. Alert broadcast channel — PASS/FAIL: [details]
+
+### Proxy Wiring
+- [ ] 6. SSE streaming path — PASS/FAIL: [details]
+
+### Hook Wiring
+- [ ] 7. Evidence hook real — PASS/FAIL: [details]
+- [ ] 8. SLM hook real — PASS/FAIL: [details]
+- [ ] 9. Barrier hook real — PASS/FAIL: [details]
+- [ ] 10. Vault hook real — PASS/FAIL: [details]
+
+### Dashboard Wiring
+- [ ] 11. /api/status — PASS/FAIL
+- [ ] 12. /api/evidence — PASS/FAIL
+- [ ] 13. /api/memory — PASS/FAIL
+- [ ] 14. /api/vault — PASS/FAIL
+- [ ] 15. /api/access — PASS/FAIL
+- [ ] 16. /api/alerts — PASS/FAIL
+- [ ] 17. /api/alerts/stream — PASS/FAIL
+
+### CLI Wiring
+- [ ] 18. setup openclaw — PASS/FAIL
+- [ ] 19. vault CLI wired — PASS/FAIL
+
+## Summary: X/19 PASS
+```

--- a/.claude/commands/trace-request.md
+++ b/.claude/commands/trace-request.md
@@ -1,0 +1,67 @@
+# Trace Request Lifecycle
+
+Trace the full request lifecycle through the Aegis adapter proxy. Read the source files and report what you find — do not modify any code.
+
+## Steps
+
+### 1. Trace `forward_request()` in `adapter/aegis-proxy/src/proxy.rs`
+
+Read the function and report:
+- Provider detection logic (what function is called, what happens for unknown providers)
+- Rate limiter check (what key is used, what happens when exceeded)
+- How the request body is read and hashed
+- How the upstream URL is constructed
+- SSE streaming detection (what headers are checked: `Content-Type: text/event-stream` and `Transfer-Encoding: chunked`)
+- How streaming responses are forwarded (chunk channel, incremental SHA-256 hasher task, evidence oneshot)
+- How non-streaming responses are buffered and inspected
+
+### 2. Check all 4 hooks in `adapter/aegis-adapter/src/hooks.rs`
+
+For each hook, report **REAL** or **STUB**:
+
+- **EvidenceHookImpl** — Does it call `recorder.record_simple()`? Does `on_request` and `on_response` both record? Report: REAL or STUB
+- **SlmHookImpl** — Does it call `aegis_slm::loopback::screen_content()`? Does it use `spawn_blocking`? Does it handle Admit/Quarantine/Reject? Report: REAL or STUB
+- **BarrierHookImpl** — Does it check `protected_files.lock()` and `mgr.is_critical()`? Does it record WriteBarrier receipts? Does it send SSE alerts? Report: REAL or STUB
+- **VaultHookImpl** — Does it call `scanner::scan_text()`? Does it return `VaultDecision::Detected` with secret summaries? Report: REAL or STUB
+
+### 3. Verify server startup wiring in `adapter/aegis-adapter/src/server.rs`
+
+Check and report:
+- Is the dashboard router created and mounted? (look for `aegis_dashboard::routes::routes()` and the `dashboard` parameter passed to `aegis_proxy::proxy::start()`)
+- Is the memory monitor spawned? (look for `tokio::spawn` with `monitor.run()`)
+- Is the barrier filesystem watcher started? (look for `notify::RecommendedWatcher` and `tokio::spawn`)
+- Is the alert broadcast channel created? (look for `tokio::sync::broadcast::channel`)
+- Are all 4 hooks wired in `create_middleware_hooks()`? (evidence, barrier, slm, vault)
+
+### 4. Check the evidence chain in `adapter/aegis-evidence/src/store.rs`
+
+Report:
+- Storage backend (SQLite WAL mode?)
+- Tables created (receipts, chain_state, rollups?)
+- `append_receipt()` — is it transactional?
+- `verify_full_chain()` — does it walk from genesis checking prev_hash links?
+
+## Output Format
+
+```
+## Request Lifecycle Trace
+
+### forward_request() — aegis-proxy/src/proxy.rs
+[your findings]
+
+### Middleware Hooks — aegis-adapter/src/hooks.rs
+- EvidenceHookImpl: REAL/STUB — [details]
+- SlmHookImpl:      REAL/STUB — [details]
+- BarrierHookImpl:  REAL/STUB — [details]
+- VaultHookImpl:    REAL/STUB — [details]
+
+### Server Startup Wiring — aegis-adapter/src/server.rs
+- Dashboard mounted:       YES/NO
+- Memory monitor spawned:  YES/NO
+- Barrier watcher started: YES/NO
+- Alert broadcast channel: YES/NO
+- All 4 hooks wired:       YES/NO
+
+### Evidence Chain — aegis-evidence/src/store.rs
+[your findings]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,274 @@
-# Neural Commons MoltBook MVP
+# Aegis Adapter — Claude Code Context
 
 ## Project Overview
-Trust infrastructure for 17,000+ MoltBook bot wardens. Two parallel Rust workspaces (adapter + cluster) with shared crypto and schema crates.
 
-## Architecture
-- **Rust-only** (no Go). axum + tower for HTTP, async-nats for NATS, sqlx for PostgreSQL, rust-libp2p for mesh.
-- **Two streams**: adapter/ (Stream A) and cluster/ (Stream B) never touch the same crate source.
-- **Shared crates**: `aegis-crypto` and `aegis-schemas` consumed by both workspaces.
-- **Wire format**: RFC 8785 canonical JSON — bytes signed = bytes on wire. Protobuf for schema generation only.
+Aegis is a **Rust HTTP proxy** that sits between an OpenClaw bot agent and its upstream LLM provider (Anthropic, OpenAI). It listens on **port 3141** (`127.0.0.1:3141`), intercepts every API call, records tamper-evident evidence receipts, and optionally screens for prompt injection, credential leaks, and unauthorized file writes.
 
-## Key Conventions
-- Phase 1 enforcement: `write_barrier` and `slm_reject` default to observe (warn,
-  don't block). `vault_block` and `memory_write` always enforce. See D30.
-- Rate limit keyed by bot identity fingerprint (not source IP). See D30.
-- `aegis --pass-through` = dumb forwarder, zero inspection.
-- Evidence receipts use UUID v7 (time-ordered), SHA-256 hash chains, Ed25519 signatures.
-- Enterprise nullable fields on every receipt (`fleet_id`, `warden_key`, `policy_url`, etc.).
-- Filesystem watcher for external write detection (not kernel hooks). Tool-mediated writes intercepted inline.
+Default mode is **observe-only** — Aegis logs and warns but never blocks. The proxy forwards traffic unchanged.
 
-## Testing
-4-layer architecture:
-1. **Contract** (<30s): schema round-trip tests — `tests/contract/`
-2. **Integration** (<10s): NATS topology — `tests/integration/`
-3. **HTTP** (<15s): axum TestClient — `tests/http/`
-4. **Scenarios** (~10min): YAML-driven Docker Compose — `tests/scenarios/`
+## Repo Structure
 
-## Building
-```bash
-cargo check                    # Quick check both workspaces
-cargo test -p aegis-crypto     # Test specific crate
-cargo test -p aegis-contract-tests  # Run Layer 1 tests
+```
+neural-commons/
+├── adapter/                        # Stream A — the local proxy
+│   ├── aegis-adapter/              # Server orchestration, hooks, config     (33 tests)
+│   │   └── src/
+│   │       ├── server.rs           # Startup: key, evidence, hooks, monitors, proxy
+│   │       ├── hooks.rs            # 4 middleware hooks bridging proxy ↔ subsystems
+│   │       ├── config.rs           # AdapterConfig (TOML deserialization)
+│   │       ├── mode.rs             # ModeController (observe/enforce/passthrough)
+│   │       ├── state.rs            # AdapterState (shared across subsystems)
+│   │       └── replay.rs           # MonotonicCounter, NonceRegistry
+│   ├── aegis-barrier/              # Write barrier — filesystem watcher       (198 tests)
+│   │   └── src/
+│   │       ├── protected_files.rs  # ProtectedFileManager, pattern matching
+│   │       ├── watcher.rs          # FileWatcher, notify event mapping
+│   │       └── types.rs            # FileScope, SensitivityClass, EXCLUDED_DIRS
+│   ├── aegis-evidence/             # Evidence chain — hash chain + SQLite     (26 tests)
+│   │   └── src/
+│   │       ├── chain.rs            # SHA-256 hash chain, receipt creation
+│   │       ├── store.rs            # SQLite WAL storage, append/query/verify
+│   │       └── lib.rs              # EvidenceRecorder (top-level API)
+│   ├── aegis-vault/                # Credential scanner                       (38 tests)
+│   │   └── src/
+│   │       └── scanner.rs          # scan_text() — regex-based secret detection
+│   ├── aegis-memory/               # Memory file monitor                      (23 tests)
+│   │   └── src/
+│   │       ├── monitor.rs          # MemoryMonitor, MemoryEvent
+│   │       ├── screen.rs           # HeuristicScreener, ScreenVerdict
+│   │       └── config.rs           # MemoryConfig (paths, interval)
+│   ├── aegis-slm/                  # SLM injection screening                  (18 tests)
+│   │   └── src/
+│   │       └── ollama.rs           # Ollama HTTP client, heuristic fallback
+│   ├── aegis-proxy/                # Core proxy engine                        (21 tests)
+│   │   └── src/
+│   │       ├── proxy.rs            # forward_request(), SSE streaming, build_router()
+│   │       ├── config.rs           # ProxyConfig, ProxyMode, Provider
+│   │       ├── middleware.rs       # Hook traits (EvidenceHook, VaultHook, etc.)
+│   │       ├── rate_limit.rs       # Token-bucket rate limiter
+│   │       ├── anthropic.rs        # Provider detection, request parsing
+│   │       └── cognitive_bridge.rs # /aegis/* tool endpoints
+│   ├── aegis-dashboard/            # Embedded web dashboard                   (4 tests)
+│   │   └── src/
+│   │       ├── routes.rs           # 8 API endpoints + SSE stream
+│   │       └── assets.rs           # Embedded HTML/JS
+│   ├── aegis-cli/                  # CLI binary entry point
+│   │   └── src/main.rs            # clap commands, flags
+│   ├── aegis-failure/              # Error types                              (8 tests)
+│   └── aegis-gateway/              # Gateway types                            (4 tests)
+├── shared/
+│   ├── aegis-crypto/               # Ed25519 + SHA-256 helpers                (10 tests)
+│   └── aegis-schemas/              # Receipt, ReceiptCore, ReceiptType        (27 contract tests)
+├── tests/
+│   ├── contract/                   # Layer 1: schema round-trip tests
+│   └── e2e/smoke_test.sh          # 10-step, 17-check end-to-end test
+├── docs/
+│   ├── QUICKSTART.md               # Warden onboarding guide
+│   └── tier1/
+│       ├── TIER1_DECISIONS.md      # Decision register
+│       ├── TIER1_DEFERRALS_AND_ROADMAP.md
+│       └── Tier1_Implementation_Plan_FINAL.md
+├── .github/workflows/
+│   ├── ci.yml                      # Push/PR: cargo test + smoke test
+│   └── release.yml                 # v* tags: cross-compile + GitHub Release
+└── DECISIONS.md                    # Full decision register (D0–D34)
 ```
 
-## Design Decisions
-See `DECISIONS.md` for the full decision register (D0-D34). Defaults are provided for all decisions.
+**Total: 406 unit tests** (aegis-barrier 198, aegis-evidence 26, aegis-vault 38, aegis-memory 23, aegis-slm 18, aegis-proxy 21, aegis-adapter 33, aegis-crypto 10, contract-tests 27, aegis-failure 8, aegis-gateway 4)
 
-## Plan
-Full implementation plan at `.claude/plans/ticklish-riding-flask.md`.
+## Request Lifecycle
+
+```
+OpenClaw POST /v1/messages
+  → proxy.rs forward_request()
+    → Provider detection (anthropic.rs detect_provider — 422 for unknown)
+    → Rate limiter check (token bucket, keyed by Ed25519 fingerprint, 1000/min burst 50)
+    → SLM hook screens input (hooks.rs SlmHookImpl → Ollama HTTP or heuristic fallback)
+    → Forward request to upstream (reqwest, 5min timeout)
+    → SSE streaming detection:
+        Content-Type: text/event-stream OR Transfer-Encoding: chunked
+        → spawn background task: read chunks → incremental SHA-256 → forward to client
+        → oneshot channel delivers final hash+size for evidence recording
+    → Non-streaming: buffer full response
+    → Vault hook scans response body (hooks.rs VaultHookImpl → scanner::scan_text)
+    → Evidence hook records receipt (hooks.rs EvidenceHookImpl → EvidenceRecorder)
+    → Response returned unchanged (observe mode) or blocked (enforce mode)
+```
+
+## Debugging Map
+
+| Symptom | File to check | What to look for |
+|---------|---------------|------------------|
+| Streaming freezes | `aegis-proxy/src/proxy.rs` L296–385 | SSE branch: `is_sse \|\| is_chunked`, chunk_tx/rx channel, background hasher task |
+| SLM admits everything | `aegis-adapter/src/hooks.rs` L216–251 | `SlmHookImpl::screen()` — check Ollama URL reachable, `fallback_to_heuristics`, `spawn_blocking` |
+| Dashboard unreachable | `aegis-adapter/src/server.rs` L139–141 | `dashboard_router` mounting: `aegis_dashboard::routes::routes(dashboard_state)` |
+| No evidence receipts | `aegis-adapter/src/hooks.rs` L48–110 | `EvidenceHookImpl::on_request/on_response` — check `recorder.record_simple()` errors |
+| Barrier doesn't alert | `aegis-adapter/src/server.rs` L206–303 | Barrier watcher spawn: `notify::RecommendedWatcher`, `barrier_alert_tx.send()` |
+| Rate limiting not working | `aegis-proxy/src/proxy.rs` L155–167 | `state.rate_limiter`, identity fingerprint key |
+| Provider detection wrong | `aegis-proxy/src/proxy.rs` L147–152 | `anthropic::detect_provider(&headers)`, `allow_any_provider` config |
+| Vault misses secrets | `aegis-adapter/src/hooks.rs` L120–148 | `VaultHookImpl::scan()` → `scanner::scan_text()` |
+| Memory monitor silent | `aegis-adapter/src/server.rs` L142–204 | Memory monitor spawn, `mode != PassThrough` guard |
+| Config not loading | `aegis-adapter/src/config.rs` | `AdapterConfig` TOML deserialization, default values |
+
+## 10 Key Source Files (Read First)
+
+1. **`adapter/aegis-adapter/src/server.rs`** — Startup orchestration: loads config, generates keys, initializes evidence, creates hooks, spawns memory monitor + barrier watcher, starts proxy with dashboard
+2. **`adapter/aegis-adapter/src/hooks.rs`** — 4 middleware hook implementations bridging proxy traits to subsystem crates (EvidenceHookImpl, VaultHookImpl, BarrierHookImpl, SlmHookImpl)
+3. **`adapter/aegis-proxy/src/proxy.rs`** — Core proxy: `forward_request()`, SSE streaming passthrough with incremental hashing, provider detection, rate limiting
+4. **`adapter/aegis-proxy/src/config.rs`** — ProxyConfig (upstream URL, listen addr, mode, provider, rate limit), ProxyMode enum
+5. **`adapter/aegis-barrier/src/protected_files.rs`** — ProtectedFileManager: system defaults (SOUL.md, AGENTS.md, etc.), warden-added files, pattern matching, 50-path cap
+6. **`adapter/aegis-evidence/src/chain.rs`** — SHA-256 hash chain: `create_receipt()`, `advance_chain_state()`, `compute_receipt_hash()`
+7. **`adapter/aegis-evidence/src/store.rs`** — SQLite WAL storage: `append_receipt()`, `get_receipt_by_seq()`, `verify_full_chain()`
+8. **`adapter/aegis-slm/src/ollama.rs`** — Ollama HTTP client for SLM screening, heuristic regex fallback
+9. **`adapter/aegis-dashboard/src/routes.rs`** — 8 dashboard API endpoints + SSE alert stream
+10. **`adapter/aegis-dashboard/src/assets.rs`** — Embedded HTML/JS dashboard
+
+## Locked Decisions
+
+| Decision | Value |
+|----------|-------|
+| Wire format | RFC 8785 JCS (canonical JSON) — bytes signed = bytes on wire |
+| Timestamps | `i64` epoch milliseconds |
+| Scores | Basis points 0–10000 |
+| Default mode | observe-only (warn, don't block) |
+| Upstream default | `https://api.anthropic.com` |
+| Listen address | `127.0.0.1:3141` |
+| SLM engine | Ollama HTTP (`http://127.0.0.1:11434`) |
+| SLM model | `llama3.2:1b` |
+| Protected files | SOUL.md, AGENTS.md, IDENTITY.md, TOOLS.md, BOOT.md, MEMORY.md, `*.memory.md`, `.env*`, config.toml |
+| Memory monitored | MEMORY.md, `memory/*.md`, HEARTBEAT.md, USER.md |
+| Providers | Anthropic + OpenAI (422 for unknown) |
+| Rate limit | 1000/min burst 50 (keyed by Ed25519 fingerprint) |
+| Binary hosting | GitHub Releases |
+| Evidence storage | SQLite WAL mode |
+| Identity | Ed25519, BIP-39 / SLIP-0010 derivation |
+| Vault encryption | AES-256-GCM, HKDF-SHA256 |
+| Enforcement (D30) | `write_barrier` and `slm_reject` default observe; `vault_block` and `memory_write` always enforce |
+
+## Building
+
+```bash
+cargo check --workspace            # Quick type-check both workspaces
+cargo test --workspace             # Run all 406 tests
+cargo build --release --bin aegis  # Release binary
+cargo test -p aegis-barrier        # Test a specific crate (198 tests)
+cargo test -p aegis-contract-tests # Layer 1 contract tests (27 tests)
+./tests/e2e/smoke_test.sh         # 10-step, 17-check end-to-end test
+```
+
+## CI/CD
+
+- **`ci.yml`** — Runs on push and PR to main: `cargo test --workspace` + smoke test
+- **`release.yml`** — Runs on `v*` tags: cross-compiles 4 platforms (linux-x86_64, darwin-x86_64, darwin-aarch64, windows-x86_64), generates SHA-256 checksums, publishes GitHub Release
+
+## Config Reference (`~/.aegis/config/config.toml`)
+
+```toml
+mode = "observe_only"              # "observe_only" | "enforce" | "pass_through"
+
+[proxy]
+listen_addr = "127.0.0.1:3141"
+upstream_url = "https://api.anthropic.com"
+max_body_size = 10485760           # 10MB
+rate_limit_per_minute = 1000
+allow_any_provider = false         # true to skip provider detection
+
+[slm]
+enabled = true
+ollama_url = "http://127.0.0.1:11434"
+model = "llama3.2:1b"
+fallback_to_heuristics = true      # regex fallback when Ollama unavailable
+
+[memory]
+memory_paths = []                  # additional paths to monitor
+hash_interval_secs = 30
+
+[enforcement]                      # D30 enforcement overrides
+write_barrier = "observe"          # "observe" (warn) or "enforce" (block)
+slm_reject = "observe"
+vault_block = "enforce"            # always enforce
+memory_write = "enforce"           # always enforce
+
+[dashboard]
+path = "/dashboard"
+```
+
+## CLI Quick Reference
+
+```bash
+aegis                              # Start proxy (observe-only, port 3141)
+aegis --enforce                    # Start with blocking enabled
+aegis --no-slm                    # Start without SLM screening (no Ollama)
+aegis --pass-through               # Dumb forwarder, zero inspection
+aegis --config /path/to/config.toml
+
+aegis setup openclaw               # Configure OpenClaw → Aegis proxy
+aegis setup openclaw --dry-run     # Preview changes
+aegis setup openclaw --revert      # Undo configuration
+
+aegis scan                         # Scan workspace for credentials
+aegis scan /path/to/dir            # Scan specific directory
+
+aegis status                       # Show adapter status
+aegis vault summary                # Credential vault overview
+aegis memory status                # Memory file health
+aegis export                       # Export evidence chain as JSON
+aegis export --verify              # Export with integrity check
+aegis dashboard                    # Open dashboard in browser
+```
+
+## Dashboard API Endpoints
+
+All mounted under the dashboard path (default `/dashboard`):
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /` | HTML dashboard page |
+| `GET /api/status` | Mode, uptime, receipt count, health |
+| `GET /api/evidence` | Receipt count, chain head, last receipt timestamp |
+| `GET /api/memory` | Tracked files, changes detected |
+| `GET /api/vault` | Detected secrets (masked), by type |
+| `GET /api/access` | Last 50 API call entries |
+| `GET /api/alerts` | Recent critical alerts (REST fallback) |
+| `GET /api/alerts/stream` | SSE stream for real-time critical alerts |
+
+## Dogfooding: Route Claude Code Through Aegis
+
+Anthropic officially supports routing Claude Code through LLM gateways using the `ANTHROPIC_BASE_URL` environment variable. See [Anthropic LLM Gateway docs](https://docs.anthropic.com/en/docs/claude-code/llm-gateway).
+
+**2-terminal setup:**
+
+```bash
+# Terminal 1: Start Aegis
+aegis --no-slm
+# Proxy is now listening on 127.0.0.1:3141
+# Dashboard at http://localhost:3141/dashboard
+```
+
+```bash
+# Terminal 2: Run Claude Code through Aegis
+export ANTHROPIC_BASE_URL=http://127.0.0.1:3141
+claude
+```
+
+**Safety notes:**
+- The `ANTHROPIC_BASE_URL` env var is per-shell — it only affects the terminal where you set it
+- To escape, close the terminal or `unset ANTHROPIC_BASE_URL`
+- Aegis runs in observe-only mode by default — it will never block Claude Code requests
+- Use `--no-slm` to avoid SLM screening overhead on Claude's own traffic
+
+**What to watch for:**
+- Streaming should work — Aegis detects SSE (`text/event-stream`) and chunked responses, forwarding them transparently while hashing incrementally
+- Evidence receipts should appear on the dashboard at `http://localhost:3141/dashboard`
+- Check `aegis export --verify` to confirm the evidence chain is intact
+
+**Troubleshooting:**
+- If Claude Code hangs: check that Aegis is running and `ANTHROPIC_BASE_URL` is set correctly
+- If streaming feels slow: ensure `--no-slm` is set (SLM screening adds latency)
+- If receipts are missing: check Aegis logs for evidence hook errors
+
+## Further Reading
+
+- [docs/tier1/TIER1_DECISIONS.md](docs/tier1/TIER1_DECISIONS.md) — Decision register with rationale
+- [docs/tier1/TIER1_DEFERRALS_AND_ROADMAP.md](docs/tier1/TIER1_DEFERRALS_AND_ROADMAP.md) — Deferred items and roadmap
+- [docs/QUICKSTART.md](docs/QUICKSTART.md) — Warden onboarding guide

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -160,6 +160,45 @@ Your OpenClaw Agent
 
 Aegis is a transparent proxy. It intercepts traffic, inspects it, records evidence, and forwards it unchanged. In observe mode, it never modifies or blocks anything. In enforce mode, it can block requests that fail SLM screening or violate write barriers.
 
+## Dogfooding: Route Claude Code Through Aegis
+
+Anthropic officially supports routing Claude Code through LLM gateways using the `ANTHROPIC_BASE_URL` environment variable. See the [Anthropic LLM Gateway documentation](https://docs.anthropic.com/en/docs/claude-code/llm-gateway) for details.
+
+This means you can run Claude Code through Aegis to monitor and record every API call Claude makes — with full evidence receipts, credential scanning, and (optionally) injection screening.
+
+**Terminal 1 — Start Aegis:**
+
+```bash
+aegis --no-slm
+# Proxy listening on 127.0.0.1:3141
+# Dashboard at http://localhost:3141/dashboard
+```
+
+**Terminal 2 — Run Claude Code through the proxy:**
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:3141
+claude
+```
+
+**What to expect:**
+- Streaming works — Aegis detects SSE and chunked responses, forwarding them transparently
+- Evidence receipts appear on the dashboard as Claude sends API calls
+- `aegis export --verify` confirms the evidence chain integrity
+
+**Safety notes:**
+- `ANTHROPIC_BASE_URL` is a per-shell env var — it only affects the terminal where you set it
+- To stop routing through Aegis: close the terminal or run `unset ANTHROPIC_BASE_URL`
+- Use `--no-slm` to skip SLM screening overhead on Claude's traffic (recommended for dogfooding)
+- Aegis runs in observe-only mode by default — it never modifies or blocks requests
+
+**Troubleshooting dogfooding:**
+- Claude Code hangs → check Aegis is running and the env var is set: `echo $ANTHROPIC_BASE_URL`
+- No receipts on dashboard → send a test message in Claude and refresh the dashboard
+- Streaming feels slow → make sure `--no-slm` is set
+
+---
+
 ## Troubleshooting
 
 **Install script says "Download failed"**


### PR DESCRIPTION
## Summary

- **Upgraded CLAUDE.md** from ~40 lines to a comprehensive debugging context (~300 lines) including: full repo structure with test counts (406 total), complete request lifecycle trace, debugging map table (symptom → file), 10 key source files list, locked decisions table, config reference, CLI quick reference, dashboard API endpoints, and dogfooding instructions
- **Added 3 custom slash commands** in `.claude/commands/`:
  - `/trace-request` — traces the request lifecycle through `proxy.rs forward_request()`, checks all 4 hooks in `hooks.rs` (evidence, SLM, barrier, vault) reporting REAL vs STUB for each, verifies `server.rs` startup wiring, and checks the evidence chain in `store.rs`
  - `/check-wiring` — audits 19 connection points with PASS/FAIL: dashboard mounted, upstream default, SSE streaming path, all 4 hooks real, memory monitor spawned, barrier watcher spawned, alert broadcast channel, all 8 dashboard API endpoints, vault CLI, setup openclaw
  - `/adapter-state` — reads config and source to report: current mode, which protections are active vs warn-only (per D30), SLM status, protected file list, and config values in effect
- **Added dogfooding section** to `docs/QUICKSTART.md` with 2-terminal setup for routing Claude Code through the Aegis proxy using the officially supported `ANTHROPIC_BASE_URL` environment variable

## Test plan

- [x] CLAUDE.md contains all requested sections (overview, structure, lifecycle, debugging map, key files, decisions, build, CI/CD, config, CLI, dashboard, dogfooding, links)
- [x] All 3 custom command files are valid markdown with clear instructions
- [x] QUICKSTART.md dogfooding section placed before Troubleshooting with safety notes
- [x] No source code changes — documentation and commands only

https://claude.ai/code/session_01CgoC2aCmrSDtpWWkCbyM4c