### PR TITLE
feat: traffic inspector with in-memory ring buffer

### DIFF
--- a/.aegis/config/config.toml
+++ b/.aegis/config/config.toml
@@ -1,0 +1,18 @@
+mode = "observe_only"
+
+[proxy]
+listen_addr = "127.0.0.1:3141"
+upstream_url = "http://localhost:1234"
+max_body_size = 10485760
+rate_limit_per_minute = 1000
+allow_any_provider = true
+
+[slm]
+enabled = false
+
+[memory]
+memory_paths = []
+hash_interval_secs = 30
+
+[dashboard]
+path = "/dashboard"

--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -109,10 +109,14 @@ pub async fn start(
         alert_tx: alert_tx.clone(),
     });
 
-    // 5b. Build dashboard shared state
+    // 5b. Create traffic store (in-memory ring buffer for dashboard inspector)
+    let traffic_store = Arc::new(aegis_dashboard::TrafficStore::new(200));
+
+    // 5c. Build dashboard shared state
     let dashboard_state = Arc::new(aegis_dashboard::DashboardSharedState {
         alert_tx: alert_tx.clone(),
         evidence: recorder.clone(),
+        traffic: traffic_store.clone(),
         mode_fn: Arc::new({
             let mc = mode_controller.clone();
             move || match mc.current() {
@@ -373,10 +377,18 @@ pub async fn start(
         "proxy server starting"
     );
 
-    aegis_proxy::proxy::start(
+    let traffic_recorder: Arc<aegis_proxy::proxy::TrafficRecorder> = {
+        let ts = traffic_store.clone();
+        Arc::new(move |method: &str, path: &str, status: u16, req: &[u8], resp: &[u8], dur: u64, streaming: bool| {
+            ts.record(method, path, status, req, resp, dur, streaming);
+        })
+    };
+
+    aegis_proxy::proxy::start_with_traffic(
         proxy_config,
         hooks,
         Some((dashboard_path, dashboard_router)),
+        Some(traffic_recorder),
     )
         .await
         .map_err(|e| StartupError::Proxy(format!("{e}")))?;

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -57,6 +57,16 @@ table.dtable tr:hover{background:#1c2128}
 .badge-blue{background:#1f2d3d;color:#58a6ff;border:1px solid #1f6feb}
 .badge-gray{background:#21262d;color:#8b949e;border:1px solid #30363d}
 .empty-state{color:#8b949e;font-size:13px;padding:16px 0}
+.chat-box{max-width:700px;margin:0 auto}
+.chat-msg{padding:10px 14px;margin:6px 0;border-radius:12px;font-size:13px;line-height:1.5;max-width:85%;white-space:pre-wrap;word-break:break-word}
+.chat-user{background:#1f3d5c;color:#c9d1d9;margin-left:auto;border-bottom-right-radius:4px}
+.chat-assistant{background:#1c2128;color:#e1e4e8;border:1px solid #30363d;border-bottom-left-radius:4px}
+.chat-system{background:#2d2a1f;color:#d29922;font-size:12px;font-style:italic;border:1px solid #9e6a03;text-align:center;max-width:100%}
+.traffic-row{cursor:pointer}
+.traffic-row:hover{background:#1c2128 !important}
+.body-pre{background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;font-family:monospace;font-size:12px;color:#c9d1d9;overflow-x:auto;max-height:400px;overflow-y:auto;white-space:pre-wrap;word-break:break-word;margin:8px 0}
+.detail-back{cursor:pointer;color:#58a6ff;font-size:13px;margin-bottom:12px;display:inline-block}
+.detail-back:hover{text-decoration:underline}
 </style>
 </head>
 <body>
@@ -73,6 +83,7 @@ table.dtable tr:hover{background:#1c2128}
 <div class="tab" data-tab="vault">Vault Scan</div>
 <div class="tab" data-tab="access">Access</div>
 <div class="tab" data-tab="memory">Memory</div>
+<div class="tab" data-tab="traffic">Traffic</div>
 <div class="tab" data-tab="alerts">Alerts</div>
 </div>
 <div class="content">
@@ -107,6 +118,12 @@ table.dtable tr:hover{background:#1c2128}
 <div class="card"><h2>Memory Integrity</h2>
 <div class="grid" id="memory-stats"></div>
 <div id="memory-files"></div>
+</div></div>
+<div class="panel" id="panel-traffic">
+<div class="card"><h2>Traffic Inspector</h2>
+<div class="grid" id="traffic-stats"></div>
+<div id="traffic-detail" style="display:none;margin-bottom:16px"></div>
+<div id="traffic-table"></div>
 </div></div>
 <div class="panel" id="panel-alerts"><div class="card"><h2>Emergency Alerts</h2><p>No alerts.</p></div></div>
 </div>
@@ -205,6 +222,12 @@ async function poll(){
       const m=await(await fetch('/dashboard/api/memory')).json();
       document.getElementById('stat-memory').textContent=m.tracked_files;
       if(activeTab==='memory'){renderMemory(m);}
+    }catch(e){}
+  }
+  if(activeTab==='traffic'){
+    try{
+      const t=await(await fetch('/dashboard/api/traffic')).json();
+      renderTraffic(t);
     }catch(e){}
   }
 }
@@ -311,6 +334,85 @@ function renderMemory(m){
   }
   h+='</table>';
   files.innerHTML=h;
+}
+let trafficDetailId=null;
+function renderTraffic(data){
+  if(trafficDetailId)return; // don't overwrite detail view
+  const stats=document.getElementById('traffic-stats');
+  const tbl=document.getElementById('traffic-table');
+  let sc='<div class="card"><div class="stat">'+data.total+'</div><div class="stat-label">Captured Requests</div></div>';
+  const streaming=data.entries?data.entries.filter(e=>e.is_streaming).length:0;
+  sc+='<div class="card"><div class="stat">'+streaming+'</div><div class="stat-label">Streaming (SSE)</div></div>';
+  const avgDur=data.entries&&data.entries.length>0?Math.round(data.entries.reduce((s,e)=>s+e.duration_ms,0)/data.entries.length):0;
+  sc+='<div class="card"><div class="stat">'+avgDur+'ms</div><div class="stat-label">Avg Latency</div></div>';
+  stats.innerHTML=sc;
+  if(!data.entries||data.entries.length===0){tbl.innerHTML='<p class="empty-state">No traffic captured yet. Send requests through the proxy to see them here.</p>';return;}
+  let h='<table class="dtable"><tr><th>#</th><th>Time</th><th>Method</th><th>Path</th><th>Status</th><th>Req Size</th><th>Resp Size</th><th>Duration</th><th>Type</th></tr>';
+  for(const e of data.entries){
+    const sc2=e.status<400?'badge-green':'badge-red';
+    h+='<tr class="traffic-row" onclick="showTrafficDetail('+e.id+')">';
+    h+='<td>'+e.id+'</td>';
+    h+='<td style="white-space:nowrap">'+fmtTimeShort(e.ts_ms)+'</td>';
+    h+='<td><span class="badge badge-blue">'+e.method+'</span></td>';
+    h+='<td style="max-width:250px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+esc(e.path)+'</td>';
+    h+='<td><span class="badge '+sc2+'">'+e.status+'</span></td>';
+    h+='<td>'+fmtBytes(e.request_size)+'</td>';
+    h+='<td>'+fmtBytes(e.response_size)+'</td>';
+    h+='<td>'+e.duration_ms+'ms</td>';
+    h+='<td>'+(e.is_streaming?'<span class="badge badge-yellow">SSE</span>':'<span class="badge badge-gray">REST</span>')+'</td>';
+    h+='</tr>';
+  }
+  h+='</table>';
+  tbl.innerHTML=h;
+}
+function fmtBytes(b){if(b<1024)return b+'B';if(b<1048576)return(b/1024).toFixed(1)+'KB';return(b/1048576).toFixed(1)+'MB';}
+async function showTrafficDetail(id){
+  trafficDetailId=id;
+  const detail=document.getElementById('traffic-detail');
+  const tbl=document.getElementById('traffic-table');
+  detail.style.display='block';
+  tbl.style.display='none';
+  detail.innerHTML='<p style="color:#8b949e">Loading...</p>';
+  try{
+    const d=await(await fetch('/dashboard/api/traffic/'+id)).json();
+    if(d.error){detail.innerHTML='<p class="empty-state">Entry not found (expired from ring buffer).</p>';return;}
+    const e=d.entry;
+    let h='<span class="detail-back" onclick="closeTrafficDetail()">\u2190 Back to traffic list</span>';
+    h+='<div style="display:flex;gap:12px;align-items:center;margin-bottom:16px">';
+    h+='<span class="badge badge-blue">'+e.method+'</span>';
+    h+='<span style="font-family:monospace;font-size:14px">'+esc(e.path)+'</span>';
+    const sc=e.status<400?'badge-green':'badge-red';
+    h+='<span class="badge '+sc+'">'+e.status+'</span>';
+    h+='<span style="color:#8b949e;font-size:12px">'+e.duration_ms+'ms</span>';
+    h+='<span style="color:#8b949e;font-size:12px">'+(e.is_streaming?'streaming':'')+'</span>';
+    h+='<span style="color:#8b949e;font-size:12px">'+fmtTime(e.ts_ms)+'</span>';
+    h+='</div>';
+    // Chat view if we have parsed messages
+    if(d.chat&&d.chat.length>0){
+      h+='<h3 style="color:#8b949e;font-size:12px;text-transform:uppercase;margin-bottom:8px">Chat View</h3>';
+      h+='<div class="chat-box">';
+      for(const m of d.chat){
+        const cls=m.role==='user'?'chat-user':m.role==='system'?'chat-system':'chat-assistant';
+        h+='<div class="chat-msg '+cls+'"><strong>'+esc(m.role)+'</strong><br>'+esc(m.content)+'</div>';
+      }
+      h+='</div>';
+    }
+    // Raw bodies
+    h+='<h3 style="color:#8b949e;font-size:12px;text-transform:uppercase;margin:16px 0 8px">Request Body ('+fmtBytes(e.request_size)+')</h3>';
+    h+='<div class="body-pre">'+fmtJson(e.request_body)+'</div>';
+    h+='<h3 style="color:#8b949e;font-size:12px;text-transform:uppercase;margin:16px 0 8px">Response Body ('+fmtBytes(e.response_size)+')</h3>';
+    h+='<div class="body-pre">'+fmtJson(e.response_body)+'</div>';
+    detail.innerHTML=h;
+  }catch(err){detail.innerHTML='<p class="empty-state">Failed to load detail.</p>';}
+}
+function closeTrafficDetail(){
+  trafficDetailId=null;
+  document.getElementById('traffic-detail').style.display='none';
+  document.getElementById('traffic-table').style.display='block';
+}
+function fmtJson(s){
+  if(!s)return'(empty)';
+  try{return esc(JSON.stringify(JSON.parse(s),null,2));}catch(e){return esc(s);}
 }
 function schedule(fn,ms){fn().finally(()=>setTimeout(()=>schedule(fn,ms),ms));}
 schedule(poll,2000);

--- a/adapter/aegis-dashboard/src/lib.rs
+++ b/adapter/aegis-dashboard/src/lib.rs
@@ -1,12 +1,14 @@
 //! aegis-dashboard: Embedded HTML dashboard
 //!
-//! 6 tabs: vulnerability scan, evidence explorer, service access, gamification,
-//! emergency alerts, memory health.
+//! 7 tabs: vulnerability scan, evidence explorer, service access, traffic inspector,
+//! gamification, emergency alerts, memory health.
 //! First screen: "nothing changed, here's what we see" — displays current state.
 //! Total size: <50KB (HTML + CSS + JS embedded in binary).
 //! Refresh: 2s recursive-setTimeout polling + SSE push for critical alerts (D12).
 
 pub mod routes;
 pub mod assets;
+pub mod traffic;
 
 pub use routes::{DashboardAlert, DashboardSharedState};
+pub use traffic::TrafficStore;

--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use aegis_evidence::EvidenceRecorder;
 use axum::{
-    extract::State,
+    extract::{Path, State},
     response::sse::{Event, KeepAlive, Sse},
     routing::get,
     Json, Router,
@@ -27,6 +27,8 @@ use futures::Stream;
 use serde::Serialize;
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+
+use crate::traffic::TrafficStore;
 
 // ── Shared alert type ────────────────────────────────────────────────────────
 
@@ -65,6 +67,8 @@ pub struct DashboardSharedState {
     pub observe_mode_checks_fn: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     /// Adapter start time for uptime calculation.
     pub start_time: Instant,
+    /// In-memory traffic inspector ring buffer.
+    pub traffic: Arc<TrafficStore>,
 }
 
 // ── Router ───────────────────────────────────────────────────────────────────
@@ -81,6 +85,8 @@ pub fn routes(state: Arc<DashboardSharedState>) -> Router {
         .route("/api/access", get(api_access))
         .route("/api/alerts", get(api_alerts))
         .route("/api/alerts/stream", get(api_alerts_stream))
+        .route("/api/traffic", get(api_traffic))
+        .route("/api/traffic/{id}", get(api_traffic_detail))
         .with_state(state)
 }
 
@@ -468,6 +474,88 @@ async fn api_alerts(
 
     let total = alerts.len() as u64;
     Json(serde_json::json!({ "alerts": alerts, "total": total }))
+}
+
+/// GET /dashboard/api/traffic — recent traffic entries (summary, no bodies).
+async fn api_traffic(
+    State(state): State<Arc<DashboardSharedState>>,
+) -> Json<serde_json::Value> {
+    let entries = state.traffic.list();
+    let summary: Vec<serde_json::Value> = entries.iter().rev().map(|e| {
+        serde_json::json!({
+            "id": e.id,
+            "ts_ms": e.ts_ms,
+            "method": e.method,
+            "path": e.path,
+            "status": e.status,
+            "request_size": e.request_size,
+            "response_size": e.response_size,
+            "duration_ms": e.duration_ms,
+            "is_streaming": e.is_streaming,
+        })
+    }).collect();
+
+    Json(serde_json::json!({
+        "total": entries.len(),
+        "entries": summary,
+    }))
+}
+
+/// GET /dashboard/api/traffic/:id — full traffic entry with bodies.
+async fn api_traffic_detail(
+    State(state): State<Arc<DashboardSharedState>>,
+    Path(id): Path<u64>,
+) -> Json<serde_json::Value> {
+    match state.traffic.get(id) {
+        Some(entry) => {
+            // Try to parse as chat messages for chat view
+            let chat_messages = parse_chat_messages(&entry.request_body, &entry.response_body);
+            Json(serde_json::json!({
+                "entry": entry,
+                "chat": chat_messages,
+            }))
+        }
+        None => Json(serde_json::json!({"error": "not found"})),
+    }
+}
+
+/// Parse OpenAI-compatible request/response into chat message list.
+fn parse_chat_messages(req_body: &str, resp_body: &str) -> Vec<serde_json::Value> {
+    let mut messages = Vec::new();
+
+    // Parse request messages
+    if let Ok(req) = serde_json::from_str::<serde_json::Value>(req_body) {
+        if let Some(msgs) = req.get("messages").and_then(|m| m.as_array()) {
+            for msg in msgs {
+                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("unknown");
+                let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                messages.push(serde_json::json!({
+                    "role": role,
+                    "content": content,
+                    "source": "request",
+                }));
+            }
+        }
+    }
+
+    // Parse response assistant message
+    if let Ok(resp) = serde_json::from_str::<serde_json::Value>(resp_body) {
+        if let Some(choices) = resp.get("choices").and_then(|c| c.as_array()) {
+            for choice in choices {
+                if let Some(msg) = choice.get("message") {
+                    let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("assistant");
+                    let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                    messages.push(serde_json::json!({
+                        "role": role,
+                        "content": content,
+                        "source": "response",
+                    }));
+                }
+            }
+        }
+    }
+
+    messages
 }
 
 /// GET /dashboard/api/alerts/stream — SSE stream for critical alert push.

--- a/adapter/aegis-dashboard/src/traffic.rs
+++ b/adapter/aegis-dashboard/src/traffic.rs
@@ -1,0 +1,118 @@
+//! In-memory traffic inspector — ephemeral ring buffer of recent requests.
+//!
+//! Stores the last 200 request/response pairs for debugging and analysis.
+//! Data is never persisted to disk — it lives only in memory and is lost on restart.
+
+use std::collections::VecDeque;
+use std::sync::RwLock;
+use serde::Serialize;
+
+/// A single captured request/response pair.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrafficEntry {
+    /// Auto-incrementing ID within this process lifetime.
+    pub id: u64,
+    /// Unix timestamp milliseconds.
+    pub ts_ms: i64,
+    /// HTTP method (GET, POST, etc.).
+    pub method: String,
+    /// Request path (e.g. /v1/chat/completions).
+    pub path: String,
+    /// HTTP status code of the response.
+    pub status: u16,
+    /// Request body (UTF-8 text, truncated to 32KB).
+    pub request_body: String,
+    /// Response body (UTF-8 text, truncated to 32KB).
+    pub response_body: String,
+    /// Request body size in bytes (original, before truncation).
+    pub request_size: usize,
+    /// Response body size in bytes (original, before truncation).
+    pub response_size: usize,
+    /// Round-trip duration in milliseconds.
+    pub duration_ms: u64,
+    /// Whether the response was streamed (SSE).
+    pub is_streaming: bool,
+}
+
+const MAX_BODY_CAPTURE: usize = 32 * 1024; // 32KB per body
+
+/// In-memory ring buffer for traffic inspection.
+pub struct TrafficStore {
+    entries: RwLock<VecDeque<TrafficEntry>>,
+    max_entries: usize,
+    next_id: RwLock<u64>,
+}
+
+impl TrafficStore {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            entries: RwLock::new(VecDeque::with_capacity(max_entries)),
+            max_entries,
+            next_id: RwLock::new(1),
+        }
+    }
+
+    /// Record a request/response pair.
+    pub fn record(
+        &self,
+        method: &str,
+        path: &str,
+        status: u16,
+        req_body: &[u8],
+        resp_body: &[u8],
+        duration_ms: u64,
+        is_streaming: bool,
+    ) {
+        let req_str = String::from_utf8_lossy(
+            &req_body[..req_body.len().min(MAX_BODY_CAPTURE)]
+        ).into_owned();
+        let resp_str = String::from_utf8_lossy(
+            &resp_body[..resp_body.len().min(MAX_BODY_CAPTURE)]
+        ).into_owned();
+
+        let id = {
+            let mut next = self.next_id.write().unwrap();
+            let id = *next;
+            *next += 1;
+            id
+        };
+
+        let entry = TrafficEntry {
+            id,
+            ts_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+            method: method.to_string(),
+            path: path.to_string(),
+            status,
+            request_body: req_str,
+            response_body: resp_str,
+            request_size: req_body.len(),
+            response_size: resp_body.len(),
+            duration_ms,
+            is_streaming,
+        };
+
+        let mut entries = self.entries.write().unwrap();
+        if entries.len() >= self.max_entries {
+            entries.pop_front();
+        }
+        entries.push_back(entry);
+    }
+
+    /// Get all entries (most recent last).
+    pub fn list(&self) -> Vec<TrafficEntry> {
+        self.entries.read().unwrap().iter().cloned().collect()
+    }
+
+    /// Get a single entry by ID.
+    pub fn get(&self, id: u64) -> Option<TrafficEntry> {
+        self.entries.read().unwrap().iter().find(|e| e.id == id).cloned()
+    }
+
+    /// Get current entry count.
+    pub fn len(&self) -> usize {
+        self.entries.read().unwrap().len()
+    }
+}

--- a/adapter/aegis-proxy/src/proxy.rs
+++ b/adapter/aegis-proxy/src/proxy.rs
@@ -34,6 +34,10 @@ use crate::config::{ProxyConfig, ProxyMode};
 use crate::error::ProxyError;
 use crate::middleware::{self, MiddlewareHooks, RequestInfo, ResponseInfo};
 
+/// Callback for recording traffic (request/response bodies) in the traffic inspector.
+/// Parameters: method, path, status, req_body, resp_body, duration_ms, is_streaming
+pub type TrafficRecorder = dyn Fn(&str, &str, u16, &[u8], &[u8], u64, bool) + Send + Sync;
+
 /// Shared application state for the proxy server.
 #[derive(Clone)]
 pub struct AppState {
@@ -45,6 +49,8 @@ pub struct AppState {
     pub identity_fingerprint: Option<String>,
     /// Per-identity rate limiter (None in pass-through mode).
     pub rate_limiter: Option<Arc<crate::rate_limit::RateLimiter>>,
+    /// Optional traffic recorder for the dashboard traffic inspector.
+    pub traffic_recorder: Option<Arc<TrafficRecorder>>,
 }
 
 /// Build the axum router for the proxy server.
@@ -81,6 +87,16 @@ pub async fn start(
     hooks: MiddlewareHooks,
     dashboard: Option<(String, Router)>,
 ) -> Result<(), ProxyError> {
+    start_with_traffic(config, hooks, dashboard, None).await
+}
+
+/// Start the proxy server with an optional traffic recorder for the dashboard inspector.
+pub async fn start_with_traffic(
+    config: ProxyConfig,
+    hooks: MiddlewareHooks,
+    dashboard: Option<(String, Router)>,
+    traffic_recorder: Option<Arc<TrafficRecorder>>,
+) -> Result<(), ProxyError> {
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(300)) // 5 min for long LLM responses
         .build()
@@ -101,6 +117,7 @@ pub async fn start(
         hooks: Arc::new(hooks),
         identity_fingerprint: None,
         rate_limiter,
+        traffic_recorder,
     };
 
     let app = build_router(state, dashboard);
@@ -324,17 +341,27 @@ async fn forward_request(
         let (evidence_tx, evidence_rx) = tokio::sync::oneshot::channel::<(String, usize)>();
 
         // Background task: read upstream chunks → hash → forward to client
+        let stream_traffic_recorder = state.traffic_recorder.clone();
+        let stream_method = method.to_string();
+        let stream_path = path.clone();
+        let stream_req_body = body_bytes.to_vec();
         tokio::spawn(async move {
             use tokio_stream::StreamExt;
             let mut hasher = Sha256::new();
             let mut total: usize = 0;
             let mut stream = std::pin::pin!(byte_stream);
+            let mut accumulated = Vec::new();
+            let capture_limit = 32 * 1024usize; // 32KB capture limit for traffic
 
             while let Some(chunk_result) = stream.next().await {
                 match chunk_result {
                     Ok(chunk) => {
                         hasher.update(&chunk);
                         total += chunk.len();
+                        if accumulated.len() < capture_limit {
+                            let remaining = capture_limit - accumulated.len();
+                            accumulated.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+                        }
                         let result: Result<bytes::Bytes, std::io::Error> = Ok(chunk);
                         if chunk_tx.send(result).await.is_err() {
                             break; // Client disconnected
@@ -352,6 +379,11 @@ async fn forward_request(
 
             let hash_hex = hex::encode(hasher.finalize());
             let _ = evidence_tx.send((hash_hex, total));
+
+            // Record streaming traffic
+            if let Some(ref recorder) = stream_traffic_recorder {
+                recorder(&stream_method, &stream_path, resp_status, &stream_req_body, &accumulated, start_time.elapsed().as_millis() as u64, true);
+            }
         });
 
         let body = Body::from_stream(tokio_stream::wrappers::ReceiverStream::new(chunk_rx));
@@ -418,6 +450,11 @@ async fn forward_request(
         }
     }
 
+    // Record traffic for dashboard inspector
+    if let Some(ref recorder) = state.traffic_recorder {
+        recorder(&method.to_string(), &path, resp_status, &body_bytes, &resp_body, duration_ms, false);
+    }
+
     // Build response
     let status = StatusCode::from_u16(resp_status)
         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
@@ -446,6 +483,7 @@ mod tests {
             hooks: Arc::new(MiddlewareHooks::default()),
             identity_fingerprint: None,
             rate_limiter: None,
+            traffic_recorder: None,
         };
         let _router = build_router(state, None);
         // If it doesn't panic, it works
@@ -459,6 +497,7 @@ mod tests {
             hooks: Arc::new(MiddlewareHooks::default()),
             identity_fingerprint: Some("abc123def456".to_string()),
             rate_limiter: None,
+            traffic_recorder: None,
         };
         assert_eq!(state.identity_fingerprint.as_deref(), Some("abc123def456"));
     }

--- a/tests/proxy_test.sh
+++ b/tests/proxy_test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# 20 end-to-end tests through Aegis proxy → LM Studio (qwen3-8b)
+# Aegis must be running on 3141, LMS on 1234
+
+PROXY="http://localhost:3141"
+MODEL="qwen/qwen3-8b"
+PASS=0
+FAIL=0
+
+run_test() {
+  local num="$1" desc="$2" payload="$3" check="$4"
+  local resp
+  resp=$(curl -s --max-time 30 -X POST "$PROXY/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>&1)
+
+  if echo "$resp" | grep -q "$check"; then
+    echo "  TEST $num PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "  TEST $num FAIL: $desc"
+    echo "    response: $(echo "$resp" | head -c 200)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "========================================="
+echo "  Aegis Proxy Tests (20 tests)"
+echo "  Proxy: $PROXY → LM Studio"
+echo "  Model: $MODEL"
+echo "========================================="
+echo ""
+
+# --- Basic chat completions ---
+
+echo "[Group 1: Basic Chat Completions]"
+
+run_test 1 "Simple greeting" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello in exactly 3 words\"}],\"max_tokens\":20}" \
+  "choices"
+
+run_test 2 "Math question" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2? Reply with just the number.\"}],\"max_tokens\":10}" \
+  "choices"
+
+run_test 3 "System + user message" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"system\",\"content\":\"You are a pirate.\"},{\"role\":\"user\",\"content\":\"Say hi\"}],\"max_tokens\":30}" \
+  "choices"
+
+run_test 4 "Multi-turn conversation" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"My name is Alice\"},{\"role\":\"assistant\",\"content\":\"Hello Alice!\"},{\"role\":\"user\",\"content\":\"What is my name?\"}],\"max_tokens\":20}" \
+  "choices"
+
+run_test 5 "Temperature 0 (deterministic)" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say exactly: test passed\"}],\"max_tokens\":10,\"temperature\":0}" \
+  "choices"
+
+echo ""
+echo "[Group 2: Edge Cases & Parameters]"
+
+run_test 6 "Max tokens = 1" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello\"}],\"max_tokens\":1}" \
+  "choices"
+
+run_test 7 "High temperature" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Write a random word\"}],\"max_tokens\":10,\"temperature\":1.5}" \
+  "choices"
+
+run_test 8 "Empty system message" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"system\",\"content\":\"\"},{\"role\":\"user\",\"content\":\"Say ok\"}],\"max_tokens\":10}" \
+  "choices"
+
+run_test 9 "Long input prompt" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Repeat after me: The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. Now say done.\"}],\"max_tokens\":20}" \
+  "choices"
+
+run_test 10 "Stop sequence" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Count from 1 to 10\"}],\"max_tokens\":50,\"stop\":[\"5\"]}" \
+  "choices"
+
+echo ""
+echo "[Group 3: Vault Security Tests]"
+
+run_test 11 "Prompt with fake API key" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"What does this API key do: sk-1234567890abcdef1234567890abcdef1234567890abcdef\"}],\"max_tokens\":30}" \
+  "choices"
+
+run_test 12 "Prompt with fake AWS key" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Is this a valid key: AKIAIOSFODNN7EXAMPLE\"}],\"max_tokens\":30}" \
+  "choices"
+
+run_test 13 "Prompt with password" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"My database password is SuperSecret123! Is it secure?\"}],\"max_tokens\":30}" \
+  "choices"
+
+run_test 14 "Prompt with bearer token" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test\"}],\"max_tokens\":30}" \
+  "choices"
+
+run_test 15 "Prompt with private key header" \
+  "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"-----BEGIN RSA PRIVATE KEY----- what is this?\"}],\"max_tokens\":30}" \
+  "choices"
+
+echo ""
+echo "[Group 4: Streaming & Model API]"
+
+echo -n "  TEST 16 "
+STREAM=$(curl -s --max-time 30 -X POST "$PROXY/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi\"}],\"max_tokens\":10,\"stream\":true}" 2>&1)
+if echo "$STREAM" | grep -q "data:"; then
+  echo "PASS: Streaming response"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: Streaming response"
+  echo "    response: $(echo "$STREAM" | head -c 200)"
+  FAIL=$((FAIL+1))
+fi
+
+echo -n "  TEST 17 "
+MODELS=$(curl -s --max-time 10 "$PROXY/v1/models" 2>&1)
+if echo "$MODELS" | grep -q "qwen"; then
+  echo "PASS: List models via proxy"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: List models via proxy"
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "[Group 5: Dashboard & Evidence Verification]"
+
+echo -n "  TEST 18 "
+STATUS=$(curl -s "$PROXY/dashboard/api/status")
+if echo "$STATUS" | grep -q '"health":"healthy"'; then
+  echo "PASS: Dashboard healthy after tests"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: Dashboard healthy after tests"
+  FAIL=$((FAIL+1))
+fi
+
+echo -n "  TEST 19 "
+EVIDENCE=$(curl -s "$PROXY/dashboard/api/evidence")
+COUNT=$(echo "$EVIDENCE" | python3 -c "import json,sys;print(json.load(sys.stdin)['total_receipts'])" 2>/dev/null)
+if [ "$COUNT" -gt 10 ] 2>/dev/null; then
+  echo "PASS: Evidence chain has $COUNT receipts (>10 expected)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: Evidence chain has $COUNT receipts (expected >10)"
+  FAIL=$((FAIL+1))
+fi
+
+echo -n "  TEST 20 "
+ACCESS=$(curl -s "$PROXY/dashboard/api/access")
+REQS=$(echo "$ACCESS" | python3 -c "import json,sys;print(json.load(sys.stdin)['total_requests'])" 2>/dev/null)
+if [ "$REQS" -gt 0 ] 2>/dev/null; then
+  echo "PASS: Access log has $REQS API calls recorded"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: Access log has $REQS API calls (expected >0)"
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed / 20 total"
+echo "========================================="


### PR DESCRIPTION
## Summary
- Adds a **Traffic Inspector** feature: in-memory ring buffer (200 entries) capturing request/response bodies as they pass through the Aegis proxy
- New **Traffic tab** in the dashboard with: traffic log table, expandable chat view (parses OpenAI-compatible messages), raw request/response body inspection
- Captures both streaming (SSE) and non-streaming traffic with 32KB body capture limit
- New API endpoints: `GET /api/traffic` (list) and `GET /api/traffic/{id}` (detail with chat parsing)
- Includes LM Studio proxy config and 20-test proxy test suite (all passing)

## Test plan
- [x] All 20 proxy tests pass (`tests/proxy_test.sh`)
- [x] `cargo check --workspace` — clean build
- [x] Non-streaming traffic captured correctly with full bodies
- [x] Streaming (SSE) traffic captured with accumulated chunks
- [x] Chat view parses OpenAI-compatible request/response messages
- [x] Ring buffer stays at 200 entries max (older entries evicted)
- [x] Dashboard Traffic tab renders table, detail view, and chat bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)