### PR TITLE
feat(vault): implement D9 kdf_version column

### DIFF
--- a/adapter/aegis-vault/src/kdf.rs
+++ b/adapter/aegis-vault/src/kdf.rs
@@ -1,26 +1,44 @@
 //! Vault key derivation (D9)
 //!
-//! HKDF-SHA256, domain "aegis-vault-v1", info = bot fingerprint.
-//! 256-bit output key for AES-256-GCM.
+//! Derives a 256-bit AES-256-GCM encryption key using HKDF-SHA256 (RFC 5869).
+//!
+//! **Confirmed parameters (D9):**
+//! - Algorithm: HKDF-SHA256
+//! - Salt: `"aegis-vault-v1"` (stable for kdf_version=1; future versions may use a different salt)
+//! - IKM: VaultKdf seed from HD path `m/44'/784'/2'/0'` (see D0: SLIP-0010 derivation)
+//! - Info: bot_fingerprint (Ed25519 public key thumbprint, hex-encoded)
+//! - Output: 32 bytes → AES-256-GCM encryption key
+//! - Nonce: unique random 12-byte nonce per secret (standard AES-GCM construction)
+//! - KDF versioning: `kdf_version` stored per-secret row in SQLite for future algorithm upgrades
+//!
+//! **Key rotation:** Wipe and rescan — no re-encryption migration in Phase 1.
 
 use hkdf::Hkdf;
 use sha2::Sha256;
 
 use crate::VaultError;
 
-/// Domain separation string for vault key derivation.
+/// Domain separation salt for vault key derivation (kdf_version=1).
+///
+/// Future KDF versions may use a different salt; this constant is stable
+/// for all secrets stored with `kdf_version = 1`.
 pub const VAULT_DOMAIN: &str = "aegis-vault-v1";
 
-/// Derive a 256-bit vault key using HKDF-SHA256.
+/// Derive a 256-bit vault key using HKDF-SHA256 (RFC 5869).
 ///
-/// - `master_key_material`: the input keying material (e.g. bot master secret)
-/// - `bot_fingerprint`: the Ed25519 public key thumbprint (hex), used as HKDF info
+/// # Arguments
+/// - `master_key_material` — IKM: the VaultKdf seed from HD path `m/44'/784'/2'/0'`
+///   (see D0: SLIP-0010 derivation)
+/// - `bot_fingerprint` — Info: the Ed25519 public key thumbprint (hex-encoded)
 ///
-/// HKDF parameters:
-///   salt  = VAULT_DOMAIN bytes ("aegis-vault-v1")
-///   ikm   = master_key_material
-///   info  = bot_fingerprint bytes
-///   len   = 32 (256 bits)
+/// # HKDF parameters (kdf_version=1)
+/// | Parameter | Value |
+/// |-----------|-------|
+/// | Algorithm | HKDF-SHA256 |
+/// | Salt      | [`VAULT_DOMAIN`] (`"aegis-vault-v1"`) |
+/// | IKM       | `master_key_material` |
+/// | Info      | `bot_fingerprint` (UTF-8 bytes) |
+/// | Output    | 32 bytes (256 bits) → AES-256-GCM key |
 pub fn derive_vault_key(
     master_key_material: &[u8],
     bot_fingerprint: &str,

--- a/adapter/aegis-vault/src/lib.rs
+++ b/adapter/aegis-vault/src/lib.rs
@@ -9,8 +9,7 @@
 //!   Rationale: plaintext credentials must never leave the adapter. An observe-mode
 //!   vault would be a completed credential leak, not a warning.
 //!   Receipt omits enforcement_mode field (always-enforce, not switchable).
-//!   TODO(D9): vault key derivation via HKDF-SHA256 must be locked before
-//!   actual encryption can be wired.
+//!   Key derivation: HKDF-SHA256 with per-row `kdf_version` for future upgrades (D9).
 
 pub mod scanner;
 pub mod storage;

--- a/adapter/aegis-vault/src/storage.rs
+++ b/adapter/aegis-vault/src/storage.rs
@@ -7,7 +7,7 @@
 //! Schema:
 //!   secrets(id TEXT PK, label TEXT, credential_type TEXT, encrypted_value BLOB,
 //!           nonce BLOB, created_ms INTEGER, updated_ms INTEGER, source_file TEXT,
-//!           masked_preview TEXT)
+//!           masked_preview TEXT, kdf_version INTEGER DEFAULT 1)
 
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
@@ -38,6 +38,9 @@ pub struct SecretEntry {
     pub created_ms: i64,
     /// When this entry was last updated (epoch ms)
     pub updated_ms: i64,
+    /// KDF version used to derive the encryption key (D9).
+    /// Version 1 = HKDF-SHA256 with salt "aegis-vault-v1".
+    pub kdf_version: u32,
 }
 
 /// A stored secret with its plaintext value (returned only when explicitly requested).
@@ -97,7 +100,8 @@ impl VaultStorage {
                     created_ms      INTEGER NOT NULL,
                     updated_ms      INTEGER NOT NULL,
                     source_file     TEXT,
-                    masked_preview  TEXT NOT NULL
+                    masked_preview  TEXT NOT NULL,
+                    kdf_version     INTEGER NOT NULL DEFAULT 1
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_secrets_type
@@ -130,10 +134,10 @@ impl VaultStorage {
             .execute(
                 "INSERT OR REPLACE INTO secrets
                     (id, label, credential_type, encrypted_value, nonce,
-                     created_ms, updated_ms, source_file, masked_preview)
+                     created_ms, updated_ms, source_file, masked_preview, kdf_version)
                 VALUES (?1, ?2, ?3, ?4, ?5,
                         COALESCE((SELECT created_ms FROM secrets WHERE id = ?1), ?6),
-                        ?6, ?7, ?8)",
+                        ?6, ?7, ?8, ?9)",
                 params![
                     id,
                     label,
@@ -143,6 +147,7 @@ impl VaultStorage {
                     now_ms,
                     source_file,
                     masked_preview,
+                    1_u32, // kdf_version=1 (HKDF-SHA256, D9)
                 ],
             )
             .map_err(|e| VaultError::Storage(format!("failed to store secret: {e}")))?;
@@ -155,7 +160,7 @@ impl VaultStorage {
         self.conn
             .query_row(
                 "SELECT id, label, credential_type, masked_preview,
-                        source_file, created_ms, updated_ms
+                        source_file, created_ms, updated_ms, kdf_version
                  FROM secrets WHERE id = ?1",
                 params![id],
                 |row| {
@@ -167,6 +172,7 @@ impl VaultStorage {
                         source_file: row.get(4)?,
                         created_ms: row.get(5)?,
                         updated_ms: row.get(6)?,
+                        kdf_version: row.get(7)?,
                     })
                 },
             )
@@ -182,7 +188,7 @@ impl VaultStorage {
             .conn
             .query_row(
                 "SELECT id, label, credential_type, masked_preview,
-                        source_file, created_ms, updated_ms,
+                        source_file, created_ms, updated_ms, kdf_version,
                         encrypted_value, nonce
                  FROM secrets WHERE id = ?1",
                 params![id],
@@ -196,9 +202,10 @@ impl VaultStorage {
                             source_file: row.get(4)?,
                             created_ms: row.get(5)?,
                             updated_ms: row.get(6)?,
+                            kdf_version: row.get(7)?,
                         },
-                        row.get(7)?,
                         row.get(8)?,
+                        row.get(9)?,
                     ))
                 },
             )
@@ -223,7 +230,7 @@ impl VaultStorage {
             .conn
             .prepare(
                 "SELECT id, label, credential_type, masked_preview,
-                        source_file, created_ms, updated_ms
+                        source_file, created_ms, updated_ms, kdf_version
                  FROM secrets ORDER BY updated_ms DESC",
             )
             .map_err(|e| VaultError::Storage(format!("prepare failed: {e}")))?;
@@ -238,6 +245,7 @@ impl VaultStorage {
                     source_file: row.get(4)?,
                     created_ms: row.get(5)?,
                     updated_ms: row.get(6)?,
+                    kdf_version: row.get(7)?,
                 })
             })
             .map_err(|e| VaultError::Storage(format!("query failed: {e}")))?


### PR DESCRIPTION
## Summary
- Add `kdf_version INTEGER NOT NULL DEFAULT 1` column to vault secrets table for future KDF algorithm upgrades
- Update `SecretEntry` struct and all SQL queries to include `kdf_version`
- Update `kdf.rs` doc comments with confirmed D9 HKDF-SHA256 parameters
- Replace `TODO(D9)` in `lib.rs` with finalized description

## Test plan
- [x] All 38 aegis-vault unit tests pass
- [x] Full workspace compiles cleanly
- [ ] CI passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)