### PR TITLE
perf: cache heuristic RegexSet + multi-thread ONNX

### DIFF
--- a/adapter/aegis-slm/src/engine/heuristic.rs
+++ b/adapter/aegis-slm/src/engine/heuristic.rs
@@ -131,16 +131,21 @@ fn normalize_leet(input: &str) -> String {
 }
 
 /// Heuristic engine — regex-based prompt injection detection.
+/// Uses a cached RegexSet compiled once (OnceLock), not per-request.
 pub struct HeuristicEngine {
-    regex_set: RegexSet,
+    regex_set: &'static RegexSet,
 }
 
+/// Compiled regex patterns — cached for the lifetime of the process.
+static HEURISTIC_REGEX_SET: std::sync::OnceLock<RegexSet> = std::sync::OnceLock::new();
+
 impl HeuristicEngine {
-    /// Create a new heuristic engine with compiled regex patterns.
+    /// Create a heuristic engine using the cached compiled regex patterns.
     pub fn new() -> Self {
-        let patterns: Vec<&str> = HEURISTIC_RULES.iter().map(|(p, _, _)| *p).collect();
-        let regex_set =
-            RegexSet::new(&patterns).expect("heuristic regex patterns must compile");
+        let regex_set = HEURISTIC_REGEX_SET.get_or_init(|| {
+            let patterns: Vec<&str> = HEURISTIC_RULES.iter().map(|(p, _, _)| *p).collect();
+            RegexSet::new(&patterns).expect("heuristic regex patterns must compile")
+        });
         Self { regex_set }
     }
 }

--- a/adapter/aegis-slm/src/engine/prompt_guard.rs
+++ b/adapter/aegis-slm/src/engine/prompt_guard.rs
@@ -59,14 +59,18 @@ impl PromptGuardEngine {
             ));
         }
 
+        // Use half the available cores for ONNX inference (leave the rest for proxy/SLM work)
+        let num_threads = (std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4) / 2).max(2);
         let session = Session::builder()
             .map_err(|e| format!("failed to create session builder: {e}"))?
             .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
             .map_err(|e| format!("failed to set optimization level: {e}"))?
-            .with_intra_threads(2)
+            .with_intra_threads(num_threads)
             .map_err(|e| format!("failed to set thread count: {e}"))?
             .commit_from_file(&model_path)
             .map_err(|e| format!("failed to load ONNX model: {e}"))?;
+
+        debug!(num_threads, "ONNX classifier using {} threads", num_threads);
 
         let tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| format!("failed to load tokenizer: {e}"))?;


### PR DESCRIPTION
## Summary
- Cache HeuristicEngine RegexSet via OnceLock (was compiling per-request)
- ONNX classifier uses 16 threads (half of 32 cores, was hardcoded to 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)