### PR TITLE
fix: enable ort download-binaries for cross-platform CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,5 +99,5 @@ toml = "0.8"
 notify = "7"
 
 # ML inference
-ort = "2.0.0-rc.12"
+ort = { version = "2.0.0-rc.12", features = ["download-binaries"] }
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }


### PR DESCRIPTION
## Summary
CI builds failing on darwin-x86_64 because `ort` had no prebuilt binaries. Added `download-binaries` feature so ONNX Runtime is fetched for each target platform during build.

Fixes CI error: `ort does not provide prebuilt binaries for the target x86_64-apple-darwin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)