### PR TITLE
feat: trust-based classifier policy — advisory for trusted channels

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -480,8 +480,19 @@ impl SlmHook for SlmHookImpl {
         Box::pin(async move {
             let config_clone = self.config.clone();
             let content_owned = content.to_string();
+            // Determine if classifier should block based on channel trust.
+            // Trusted/Full channels: classifier is advisory (don't block on false positives).
+            // Public/Unknown channels: classifier blocks (strict screening).
+            let classifier_blocking = {
+                let trust = aegis_proxy::cognitive_bridge::get_registered_channel_trust();
+                match trust.as_ref().map(|t| &t.trust_level) {
+                    Some(aegis_schemas::TrustLevel::Full) |
+                    Some(aegis_schemas::TrustLevel::Trusted) => false, // advisory
+                    _ => true, // blocking for public/unknown/restricted
+                }
+            };
             let result = tokio::task::spawn_blocking(move || {
-                aegis_slm::loopback::screen_fast_layers(&config_clone, &content_owned, None)
+                aegis_slm::loopback::screen_fast_layers(&config_clone, &content_owned, None, classifier_blocking)
             })
             .await;
 

--- a/adapter/aegis-slm/src/loopback.rs
+++ b/adapter/aegis-slm/src/loopback.rs
@@ -93,7 +93,11 @@ pub fn screen_content(config: &LoopbackConfig, content: &str) -> ScreeningDecisi
 /// Run only the fast layers: heuristic + ProtectAI classifier (<10ms).
 /// Returns Some(result) if a threat was caught, None if content is clean
 /// and needs deep SLM analysis.
-pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profile: Option<&HolsterProfile>) -> Option<ScreeningResult> {
+/// `classifier_blocking`: if false, classifier findings are logged as advisory
+/// (returns None to let the SLM handle it) instead of quarantining.
+/// Set to false for trusted channels where the classifier may false-positive
+/// on legitimate orchestration text.
+pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profile: Option<&HolsterProfile>, classifier_blocking: bool) -> Option<ScreeningResult> {
     use std::time::Instant;
     let pipeline_start = Instant::now();
 
@@ -121,20 +125,26 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
 
     if let Some((true, prob)) = classifier_signal {
         if prob > 0.5 {
-            info!(prob, "ProtectAI classifier: MALICIOUS, fast-path quarantine");
-            return Some(ScreeningResult {
-                decision: ScreeningDecision::Quarantine(format!(
-                    "prompt_guard: MALICIOUS (prob={prob:.4})"
-                )),
-                enriched: None,
-                holster: None,
-                timing: ScreeningTiming {
-                    total_ms: pipeline_start.elapsed().as_millis() as u64,
-                    classifier_ms,
-                    engine: "prompt-guard".to_string(),
-                    ..Default::default()
-                },
-            });
+            if classifier_blocking {
+                info!(prob, "ProtectAI classifier: MALICIOUS, fast-path quarantine");
+                return Some(ScreeningResult {
+                    decision: ScreeningDecision::Quarantine(format!(
+                        "prompt_guard: MALICIOUS (prob={prob:.4})"
+                    )),
+                    enriched: None,
+                    holster: None,
+                    timing: ScreeningTiming {
+                        total_ms: pipeline_start.elapsed().as_millis() as u64,
+                        classifier_ms,
+                        engine: "prompt-guard".to_string(),
+                        ..Default::default()
+                    },
+                });
+            } else {
+                // Advisory mode: classifier flagged it but trust level says don't block.
+                // Log and let the SLM make the final decision.
+                info!(prob, "ProtectAI classifier: suspicious (advisory, trusted channel — forwarding to SLM)");
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
ProtectAI classifier false-positived on legitimate OpenClaw subagent orchestration text ("You are running as a subagent") — quarantining benign requests.

## Solution
Classifier role determined by channel trust level:
- **Public/Unknown**: classifier **blocks** (current strict behavior)
- **Trusted/Full**: classifier is **advisory** (logs finding, forwards to SLM for final decision)
- **Heuristic**: always blocks regardless of trust (zero false positives)

## Test Results (15 scenarios)
| Scenario | Public/Unknown | Trusted/Full |
|----------|---------------|-------------|
| Subagent orchestration (was FP) | Quarantined | **Admitted** |
| Real injection | Caught | Caught (heuristic) |
| Benign | Admitted | Admitted |
| SSRF | Caught | Caught (heuristic) |
| Social engineering | Caught (classifier) | SLM + metaprompt |

🤖 Generated with [Claude Code](https://claude.com/claude-code)