### PR TITLE
feat: signed channel registration — Ed25519 authenticated trust

### DIFF
--- a/adapter/aegis-proxy/src/channel_trust.rs
+++ b/adapter/aegis-proxy/src/channel_trust.rs
@@ -79,32 +79,36 @@ pub fn verify_cert(cert: &ChannelCert, pubkey_bytes: &[u8]) -> bool {
     // Decode pubkey
     let pubkey_array: [u8; 32] = match pubkey_bytes.try_into() {
         Ok(a) => a,
-        Err(_) => return false,
+        Err(_) => { warn!("verify_cert: pubkey wrong length {}", pubkey_bytes.len()); return false; },
     };
     let verifying_key = match VerifyingKey::from_bytes(&pubkey_array) {
         Ok(k) => k,
-        Err(_) => return false,
+        Err(e) => { warn!("verify_cert: invalid pubkey: {e}"); return false; },
     };
 
     // Decode signature from hex
     let sig_bytes = match hex::decode(&cert.sig) {
         Ok(b) => b,
-        Err(_) => return false,
+        Err(e) => { warn!("verify_cert: sig hex decode failed: {e}"); return false; },
     };
     let sig_array: [u8; 64] = match sig_bytes.try_into() {
         Ok(a) => a,
-        Err(_) => return false,
+        Err(v) => { warn!("verify_cert: sig wrong length {}", v.len()); return false; },
     };
     let signature = Signature::from_bytes(&sig_array);
 
     // Verify
+    debug!(
+        payload_len = payload_bytes.len(),
+        "verifying channel cert signature"
+    );
     match verifying_key.verify(&payload_bytes, &signature) {
         Ok(()) => {
             debug!(channel = %cert.channel, user = %cert.user, "channel cert verified");
             true
         }
-        Err(_) => {
-            warn!(channel = %cert.channel, "channel cert signature invalid");
+        Err(e) => {
+            warn!(channel = %cert.channel, error = %e, "channel cert signature invalid");
             false
         }
     }

--- a/adapter/aegis-proxy/src/cognitive_bridge.rs
+++ b/adapter/aegis-proxy/src/cognitive_bridge.rs
@@ -111,6 +111,12 @@ struct RegisterChannelRequest {
     /// User identifier (e.g. "telegram:user:67890")
     #[serde(default)]
     user: Option<String>,
+    /// Unix epoch milliseconds when this registration was created
+    #[serde(default)]
+    ts: Option<i64>,
+    /// Ed25519 signature (hex) over canonical JSON of {channel, ts, user}
+    #[serde(default)]
+    sig: Option<String>,
 }
 
 /// Response for channel registration and context queries.
@@ -176,22 +182,68 @@ pub fn get_channel_registry() -> Vec<ChannelRecord> {
 async fn register_channel_handler(
     State(state): State<crate::proxy::AppState>,
     Json(req): Json<RegisterChannelRequest>,
-) -> Json<ChannelContextResponse> {
-    // Resolve trust from config based on channel pattern
+) -> (axum::http::StatusCode, Json<ChannelContextResponse>) {
     let trust_config = state.trust_config.as_ref().cloned().unwrap_or_default();
 
-    // Build a minimal cert for trust resolution
+    // Verify signature if signing_pubkey is configured
+    let sig_verified = if let Some(ref pubkey_bytes) = trust_config.signing_pubkey {
+        // Signing pubkey is set — require valid signature
+        match (&req.ts, &req.sig) {
+            (Some(ts), Some(sig)) => {
+                // Check timestamp freshness (15 second window)
+                let now = crate::middleware::now_ms();
+                let age_ms = (now - ts).abs();
+                if age_ms > 15_000 {
+                    tracing::warn!(channel = %req.channel, age_ms, "channel registration rejected: timestamp too old");
+                    return (axum::http::StatusCode::UNAUTHORIZED, Json(ChannelContextResponse {
+                        channel: None, user: None, trust_level: "rejected".to_string(),
+                        ssrf_allowed: false, registered: false,
+                    }));
+                }
+                // Build signing payload and verify
+                let cert = aegis_schemas::ChannelCert {
+                    channel: req.channel.clone(),
+                    user: req.user.clone().unwrap_or_default(),
+                    trust: String::new(),
+                    ts: *ts,
+                    sig: sig.clone(),
+                };
+                let verified = crate::channel_trust::verify_cert(&cert, pubkey_bytes);
+                if !verified {
+                    tracing::warn!(channel = %req.channel, "channel registration rejected: invalid signature");
+                    return (axum::http::StatusCode::UNAUTHORIZED, Json(ChannelContextResponse {
+                        channel: None, user: None, trust_level: "rejected".to_string(),
+                        ssrf_allowed: false, registered: false,
+                    }));
+                }
+                true
+            }
+            _ => {
+                // Signing pubkey configured but no sig provided — reject
+                tracing::warn!(channel = %req.channel, "channel registration rejected: signature required but not provided");
+                return (axum::http::StatusCode::UNAUTHORIZED, Json(ChannelContextResponse {
+                    channel: None, user: None, trust_level: "rejected".to_string(),
+                    ssrf_allowed: false, registered: false,
+                }));
+            }
+        }
+    } else {
+        // No signing pubkey configured — accept unsigned (backward compatible)
+        false
+    };
+
+    // Build cert for trust resolution
     let cert = aegis_schemas::ChannelCert {
         channel: req.channel.clone(),
         user: req.user.clone().unwrap_or_default(),
-        trust: String::new(), // agent doesn't claim trust
-        ts: crate::middleware::now_ms(),
-        sig: String::new(),
+        trust: String::new(),
+        ts: req.ts.unwrap_or_else(crate::middleware::now_ms),
+        sig: req.sig.clone().unwrap_or_default(),
     };
 
     let trust = crate::channel_trust::resolve_trust(
         Some(&cert),
-        false, // not signature-verified (came via tool call)
+        sig_verified,
         &trust_config,
     );
 
@@ -236,7 +288,7 @@ async fn register_channel_handler(
         }
     }
 
-    Json(response)
+    (axum::http::StatusCode::OK, Json(response))
 }
 
 /// GET /aegis/channel-context — return current active channel + full registry.

--- a/plugins/aegis-channel-trust/index.ts
+++ b/plugins/aegis-channel-trust/index.ts
@@ -2,36 +2,143 @@
  * Aegis Channel Trust Plugin for OpenClaw
  *
  * Automatically registers channel context with Aegis on every incoming message.
- * Aegis uses the channel context to resolve trust levels from its [trust] config
- * and adjust screening sensitivity accordingly.
+ * Signs registrations with the bot's Ed25519 identity key for authentication.
  *
  * Flow:
  *   1. Message arrives from Telegram/Discord/Slack/etc.
  *   2. This plugin fires on message_received hook
- *   3. Calls POST /aegis/register-channel with channel + user context
- *   4. Aegis maps channel to trust level (full/trusted/public/restricted)
- *   5. All subsequent proxy requests use that trust level
+ *   3. Signs {channel, user, ts} with the bot's Ed25519 key
+ *   4. Calls POST /aegis/register-channel with signed payload
+ *   5. Aegis verifies signature, resolves trust level
+ *   6. All subsequent proxy requests use that trust level
  *
- * The agent cannot fake its channel — context comes from OpenClaw's transport
- * layer, not from the LLM output.
+ * The registration is signed — a rogue process cannot fake a channel.
  *
  * Install: openclaw plugins install ./plugins/aegis-channel-trust
- * Config:  plugins.entries.aegis-channel-trust.aegisUrl = "http://127.0.0.1:3141"
+ * Config:
+ *   plugins.entries.aegis-channel-trust.aegisUrl = "http://127.0.0.1:3141"
+ *   plugins.entries.aegis-channel-trust.identityKeyPath = ".aegis/identity.key"
  */
 
 import type { OpenClawPluginDefinition } from "openclaw/plugin-sdk";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 
 const DEFAULT_AEGIS_URL = "http://127.0.0.1:3141";
+const DEFAULT_KEY_PATH = ".aegis/identity.key";
+
+/**
+ * Sign a channel registration payload with Ed25519.
+ * Returns hex-encoded signature.
+ */
+function signRegistration(
+  channel: string,
+  user: string,
+  ts: number,
+  secretKeyBytes: Buffer
+): string {
+  // Build canonical payload — keys MUST be sorted alphabetically
+  // to match Rust's BTreeMap ordering in verify_cert
+  const payload = JSON.stringify({ channel, trust: "", ts, user });
+  const payloadBytes = Buffer.from(payload, "utf-8");
+
+  // Ed25519 signing with Node.js crypto
+  // The secret key is 32 bytes (seed), need to create the full keypair
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.concat([
+      // PKCS8 DER prefix for Ed25519
+      Buffer.from("302e020100300506032b657004220420", "hex"),
+      secretKeyBytes,
+    ]),
+    format: "der",
+    type: "pkcs8",
+  });
+
+  const sig = crypto.sign(null, payloadBytes, privateKey);
+  return sig.toString("hex");
+}
 
 const plugin: OpenClawPluginDefinition = {
   id: "aegis-channel-trust",
   name: "Aegis Channel Trust",
 
   register(api) {
-    const aegisUrl = api.config?.plugins?.entries?.["aegis-channel-trust"]?.aegisUrl
-      ?? DEFAULT_AEGIS_URL;
+    const aegisUrl =
+      api.config?.plugins?.entries?.["aegis-channel-trust"]?.aegisUrl ??
+      DEFAULT_AEGIS_URL;
+    const keyPath =
+      api.config?.plugins?.entries?.["aegis-channel-trust"]?.identityKeyPath ??
+      DEFAULT_KEY_PATH;
 
     let lastRegistered = "";
+    let secretKey: Buffer | null = null;
+
+    // Try to load the identity key for signing
+    try {
+      const resolvedPath = path.resolve(process.cwd(), keyPath);
+      if (fs.existsSync(resolvedPath)) {
+        secretKey = fs.readFileSync(resolvedPath);
+        if (secretKey.length === 32) {
+          api.log?.info?.(`Aegis: loaded identity key from ${resolvedPath}`);
+        } else {
+          api.log?.warn?.(
+            `Aegis: identity key at ${resolvedPath} is ${secretKey.length} bytes (expected 32)`
+          );
+          secretKey = null;
+        }
+      } else {
+        api.log?.debug?.(
+          `Aegis: no identity key at ${resolvedPath} — registrations will be unsigned`
+        );
+      }
+    } catch (err) {
+      api.log?.debug?.(`Aegis: could not load identity key: ${err}`);
+    }
+
+    async function registerChannel(channel: string, user: string) {
+      const key = `${channel}:${user}`;
+      if (key === lastRegistered) return;
+
+      const ts = Date.now();
+      const body: Record<string, unknown> = { channel, user, ts };
+
+      // Sign if we have the identity key
+      if (secretKey) {
+        try {
+          body.sig = signRegistration(channel, user, ts, secretKey);
+        } catch (err) {
+          api.log?.debug?.(`Aegis: signing failed: ${err}`);
+        }
+      }
+
+      try {
+        const resp = await fetch(`${aegisUrl}/aegis/register-channel`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(2000),
+        });
+
+        if (resp.ok) {
+          const data = (await resp.json()) as {
+            trust_level: string;
+            ssrf_allowed: boolean;
+          };
+          lastRegistered = key;
+          api.log?.debug?.(
+            `Aegis: registered ${channel} → trust=${data.trust_level} signed=${!!secretKey}`
+          );
+        } else {
+          const text = await resp.text().catch(() => "");
+          api.log?.warn?.(
+            `Aegis: registration failed: HTTP ${resp.status} ${text.substring(0, 100)}`
+          );
+        }
+      } catch (err) {
+        api.log?.debug?.(`Aegis: registration skipped: ${err}`);
+      }
+    }
 
     // Register channel context on every incoming message
     api.on("message_received", async (event, ctx) => {
@@ -39,71 +146,35 @@ const plugin: OpenClawPluginDefinition = {
       const conversationId = ctx.conversationId || "default";
       const from = event.from || "unknown";
 
-      // Detect conversation type from ID patterns:
-      // Telegram: positive IDs = DM, negative IDs = group
-      // Discord: channels have specific formats
-      // Default: use "chat" as generic type
+      // Detect conversation type
       let chatType = "chat";
       const convNum = parseInt(conversationId, 10);
       if (channelId === "telegram") {
-        chatType = (convNum < 0 || conversationId.startsWith("-")) ? "group" : "dm";
+        chatType =
+          convNum < 0 || conversationId.startsWith("-") ? "group" : "dm";
       } else if (channelId === "discord") {
         chatType = "channel";
       } else if (channelId === "whatsapp") {
         chatType = conversationId.includes("@g.us") ? "group" : "dm";
       }
 
-      // Build channel identifier: platform:type:id
-      // Strip platform prefix from conversationId if present (e.g. "telegram:123" → "123")
+      // Strip platform prefix from conversationId
       const cleanConvId = conversationId.startsWith(`${channelId}:`)
         ? conversationId.slice(channelId.length + 1)
         : conversationId;
+
       const channel = `${channelId}:${chatType}:${cleanConvId}`;
       const user = `${channelId}:user:${from}`;
 
-      // Skip if same channel already registered (avoid redundant calls)
-      const key = `${channel}:${user}`;
-      if (key === lastRegistered) return;
-
-      try {
-        const resp = await fetch(`${aegisUrl}/aegis/register-channel`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ channel, user }),
-          signal: AbortSignal.timeout(2000), // 2s timeout
-        });
-
-        if (resp.ok) {
-          const data = await resp.json() as { trust_level: string; ssrf_allowed: boolean };
-          lastRegistered = key;
-          api.log?.debug?.(
-            `Aegis channel registered: ${channel} → trust=${data.trust_level} ssrf=${data.ssrf_allowed}`
-          );
-        } else {
-          api.log?.warn?.(`Aegis channel registration failed: HTTP ${resp.status}`);
-        }
-      } catch (err) {
-        // Non-fatal — Aegis might not be running. Fail silently.
-        api.log?.debug?.(`Aegis channel registration skipped: ${err}`);
-      }
+      await registerChannel(channel, user);
     });
 
-    // Also register on session start (in case no message_received fires)
+    // Also register on session start
     api.on("session_start", async (_event, ctx) => {
       const channelId = ctx.channelId || "unknown";
       const channel = `${channelId}:session:${ctx.sessionId || "default"}`;
       const user = `${channelId}:agent:${ctx.agentId || "default"}`;
-
-      try {
-        await fetch(`${aegisUrl}/aegis/register-channel`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ channel, user }),
-          signal: AbortSignal.timeout(2000),
-        });
-      } catch {
-        // Non-fatal
-      }
+      await registerChannel(channel, user);
     });
   },
 };


### PR DESCRIPTION
## Problem
Any local process could call POST /aegis/register-channel and claim any channel — no authentication.

## Solution
Ed25519 signature verification on channel registration:
- Plugin signs {channel, trust, ts, user} with bot's identity key
- Aegis verifies against configured signing_pubkey
- 15-second timestamp window prevents replay
- HTTP 401 for invalid/missing/expired signatures
- Backward compatible: no pubkey = accept unsigned

## Test Results (9/9)
| Scenario | Result |
|----------|--------|
| Valid signed DM (trusted) | ✅ 200 |
| Valid signed owner DM (full) | ✅ 200 |
| Valid signed group (public) | ✅ 200 |
| Valid signed unknown channel | ✅ 200 |
| Missing signature | ✅ 401 rejected |
| Bad signature | ✅ 401 rejected |
| Old timestamp (60s) | ✅ 401 rejected |
| Future timestamp (60s) | ✅ 401 rejected |
| Node.js + Python signing | ✅ verified |

🤖 Generated with [Claude Code](https://claude.com/claude-code)