### PR TITLE
docs: channel trust — trust model, CLI, plugin, security

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,20 @@ neural-commons/
 ## Request Lifecycle
 
 ```
-OpenClaw POST /v1/messages
+OpenClaw message_received → aegis-channel-trust plugin signs & registers channel
+  → POST /aegis/register-channel {channel, user, ts, sig}
+  → Aegis verifies Ed25519 signature, resolves trust level from config patterns
+
+OpenClaw POST /v1/messages (or /v1/chat/completions)
   → proxy.rs forward_request()
     → Provider detection (anthropic.rs detect_provider — 422 for unknown)
+    → Channel trust resolution (cognitive_bridge → trust level → holster preset)
     → Rate limiter check (token bucket, keyed by Ed25519 fingerprint, 1000/min burst 50)
-    → SLM hook screens input (hooks.rs SlmHookImpl → Ollama HTTP or heuristic fallback)
+    → 4-layer screening:
+        1. Heuristic (<1ms) — regex patterns + SSRF detection
+        2. ProtectAI Classifier (~30ms) — ONNX DeBERTa-v2 (blocking on public, advisory on trusted)
+        3. SLM Deep Analysis (async) — Qwen3-30B combined prompt, runs alongside LLM forwarding
+        4. Metaprompt (0ms) — 7 security rules injected into system message
     → Forward request to upstream (reqwest, 5min timeout)
     → SSE streaming detection:
         Content-Type: text/event-stream OR Transfer-Encoding: chunked
@@ -198,6 +207,18 @@ memory_write = "enforce"           # always enforce
 
 [dashboard]
 path = "/dashboard"
+
+[trust]
+default_level = "unknown"
+signing_pubkey = "<hex Ed25519 pubkey>"  # from 'aegis trust pubkey'
+
+[[trust.channels]]                     # channel pattern → trust level
+pattern = "telegram:dm:owner"
+level = "full"                         # full/trusted/public/restricted/unknown
+
+[[trust.channels]]
+pattern = "openclaw:web:*"
+level = "trusted"
 ```
 
 ## CLI Quick Reference
@@ -212,6 +233,16 @@ aegis --config /path/to/config.toml
 aegis setup openclaw               # Configure OpenClaw → Aegis proxy
 aegis setup openclaw --dry-run     # Preview changes
 aegis setup openclaw --revert      # Undo configuration
+
+aegis trust register <channel>     # Register channel with signed Ed25519 cert
+aegis trust register openclaw:web:session1  # Example: web chat channel
+aegis trust context                # Show active channel + full registry
+aegis trust pubkey                 # Show signing pubkey for config
+
+aegis slm status                   # Show SLM configuration
+aegis slm use qwen/qwen3-30b-a3b  # Switch SLM model
+aegis slm engine openai            # Switch engine (ollama/openai)
+aegis slm server http://localhost:1234  # Set SLM server URL
 
 aegis scan                         # Scan workspace for credentials
 aegis scan /path/to/dir            # Scan specific directory
@@ -240,6 +271,18 @@ All mounted under the dashboard path (default `/dashboard`):
 | `GET /api/alerts/stream` | SSE stream for real-time critical alerts |
 | `GET /api/traffic` | Traffic inspector summary (no bodies) |
 | `GET /api/traffic/{id}` | Traffic entry detail with bodies + chat view |
+| `GET /api/slm` | SLM screening entries with verdicts, timing, trust |
+| `GET /api/trust` | Channel trust overview + screening by trust level |
+
+### Cognitive Bridge Endpoints (on proxy port, not dashboard)
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /aegis/register-channel` | Register channel with signed Ed25519 cert |
+| `GET /aegis/channel-context` | Active channel + full channel registry |
+| `GET /aegis/status` | Adapter status |
+| `POST /aegis/scan` | Trigger manual scan |
+| `GET /aegis/evidence` | Evidence summary |
 
 ## Dogfooding: Route Claude Code Through Aegis
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,14 @@ aegis --pass-through               # zero inspection, metadata-only receipts
 aegis setup openclaw               # configure OpenClaw integration
 aegis setup openclaw --revert      # undo configuration
 
+# Channel trust
+aegis trust register <channel>     # register channel with signed Ed25519 cert
+aegis trust context                # show active channel + full registry
+aegis trust pubkey                 # show signing pubkey for config
+
 # SLM model management
 aegis slm status                   # show current SLM config
-aegis slm use qwen2.5:1.5b        # switch model
+aegis slm use qwen/qwen3-30b-a3b  # switch model
 aegis slm engine openai            # switch engine (ollama/openai)
 aegis slm server http://localhost:1234  # set server URL
 

--- a/docs/OPENCLAW_INTEGRATION.md
+++ b/docs/OPENCLAW_INTEGRATION.md
@@ -17,13 +17,21 @@ Route your OpenClaw bot's LLM traffic through Aegis for inspection, evidence rec
                                  │
                     subagent ────┤ lmstudio/qwen/qwen3-8b
                                  │
+              aegis-channel-trust plugin
+              signs & registers channel ──► POST /aegis/register-channel
+                                 │
                                  ▼
                           ┌──────────────┐
                           │    Aegis     │
                           │   Proxy      │
                           │  (:3141)     │
+                          │              │
+                          │  1. Verify channel cert (Ed25519)
+                          │  2. Resolve trust level
+                          │  3. 4-layer screening pipeline
+                          │  4. Record evidence receipt
                           └──────┬───────┘
-                                 │ evidence, vault scan, traffic capture
+                                 │
                                  ▼
                           ┌──────────────┐
                           │  LM Studio   │
@@ -198,11 +206,13 @@ open http://127.0.0.1:3141/dashboard
 
 | Feature | Status | Details |
 |---------|--------|---------|
+| 4-layer screening | Active | Heuristic (<1ms) + ProtectAI classifier (~30ms) + SLM (2-3s async) + metaprompt |
+| Channel trust | Active | Ed25519 signed channel certs, trust-based screening policy |
 | Request body | Full | Complete prompt including system instructions and tool definitions |
 | Response body | Up to 256KB | Streaming SSE events captured incrementally |
-| Evidence receipt | Per request | SHA-256 hash chain entry with request/response hashes |
+| Evidence receipt | Per request | SHA-256 hash chain entry with request/response hashes + channel trust |
 | Vault scanning | Active | Scans for credentials in request/response bodies |
-| Traffic inspector | Active | Full request/response visible in dashboard |
+| Traffic inspector | Active | Full request/response visible in dashboard with screening detail |
 | Barrier monitoring | Active | Watches workspace files for tampering |
 
 ### API Endpoints Used
@@ -411,9 +421,104 @@ Then in `openclaw.json`, add an OpenAI provider override:
 
 ---
 
+## Channel Trust
+
+Aegis resolves a trust level per-channel, which determines how aggressively content is screened. The `aegis-channel-trust` OpenClaw plugin handles this automatically.
+
+### How It Works
+
+1. A Telegram message arrives → OpenClaw's `message_received` hook fires
+2. The `aegis-channel-trust` plugin signs a channel registration with the bot's Ed25519 identity key
+3. Plugin POSTs to `POST /aegis/register-channel` with `{channel, user, ts, sig}`
+4. Aegis verifies the signature and resolves trust level from `[trust]` config patterns
+5. All subsequent LLM requests use that trust level for screening decisions
+
+### Trust Levels
+
+| Channel Pattern | Trust Level | Classifier | SSRF |
+|-----------------|------------|------------|------|
+| `telegram:dm:owner` | full | Advisory | Allowed |
+| `telegram:dm:*` | trusted | Advisory | Blocked |
+| `telegram:group:*` | public | Blocking | Blocked |
+| `openclaw:web:*` | trusted | Advisory | Blocked |
+| `cli:local:*` | full | Advisory | Allowed |
+| No registration | unknown | Blocking | Blocked |
+
+### Plugin Installation
+
+The plugin is at `plugins/aegis-channel-trust/`. To enable it in OpenClaw:
+
+1. Add the plugin to OpenClaw's plugin config
+2. Add `aegis-channel-trust` to `plugins.allow` in `openclaw.json`
+3. Ensure `.aegis/identity.key` exists (Aegis creates it on first start)
+
+The plugin searches for the identity key in:
+- Configured path (default: `.aegis/identity.key`)
+- `$CWD/.aegis/identity.key`
+- `$HOME/.aegis/data/identity.key`
+- `$HOME/aegis/neural-commons/.aegis/identity.key`
+
+### Security Model
+
+The plugin signs registrations with the bot's **private** Ed25519 key. Aegis verifies against the **public** key configured in `[trust] signing_pubkey`. Without the private key, a channel cannot be registered — unsigned requests are rejected (HTTP 401).
+
+This means:
+- Prompt injection cannot fake a channel registration (no key access)
+- The warden controls which channels get which trust level (config patterns)
+- The trust level determines screening behavior, not the registrant's claim
+
+### CLI Testing
+
+Test channel registration manually without the plugin:
+
+```bash
+# Register a channel
+aegis trust register openclaw:web:test-session
+aegis trust register telegram:dm:owner --user telegram:user:12345
+
+# Check current trust state
+aegis trust context
+
+# Show pubkey (for config.toml setup)
+aegis trust pubkey
+```
+
+### Configuration
+
+Add to `.aegis/config.toml`:
+
+```toml
+[trust]
+default_level = "unknown"
+signing_pubkey = "<from 'aegis trust pubkey'>"
+
+[[trust.channels]]
+pattern = "telegram:dm:owner"
+level = "full"
+
+[[trust.channels]]
+pattern = "telegram:dm:*"
+level = "trusted"
+
+[[trust.channels]]
+pattern = "telegram:group:*"
+level = "public"
+
+[[trust.channels]]
+pattern = "openclaw:web:*"
+level = "trusted"
+```
+
+### Dashboard
+
+The **Channel Trust** tab in the dashboard shows all registered channels, their trust levels, request counts, and per-channel screening history.
+
+---
+
 ## Security Notes
 
 - The OpenClaw gateway token is sensitive — it provides full operator access. Keep it on localhost only.
 - Aegis runs in **observe-only** mode by default. It logs but never blocks traffic.
 - The Telegram bot token in `openclaw.json` should not be committed to version control.
 - Evidence receipts are stored locally in SQLite. Back up `~/.aegis/data/evidence.db`.
+- The identity key (`.aegis/identity.key`) is the root of trust for channel registration. Protect it like a private key.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -106,6 +106,10 @@ aegis setup openclaw --revert  # undo configuration
 aegis scan                   # scan workspace for credentials
 aegis scan /path/to/dir      # scan specific directory
 
+aegis trust register <ch>    # register channel with signed cert
+aegis trust context          # show current channel trust
+aegis trust pubkey           # show signing pubkey
+
 aegis status                 # show adapter status
 aegis vault summary          # credential vault overview
 aegis memory status          # memory file health

--- a/skills/aegis-channel-trust/SKILL.md
+++ b/skills/aegis-channel-trust/SKILL.md
@@ -1,41 +1,141 @@
 ---
 name: aegis-channel-trust
 version: 1.0.0
-description: Reference documentation for Aegis channel trust levels
+description: Channel trust — automatic channel registration, trust resolution, and CLI tools
 metadata: {"moltbot":{"emoji":"🛡️","category":"security","api_base":"http://127.0.0.1:3141/aegis"}}
 ---
 
 # Aegis Channel Trust
 
-Aegis applies different security screening levels based on which channel you're operating in. Channel registration is handled automatically by the `aegis-channel-trust` plugin — you don't need to do anything manually.
+Aegis applies different security screening levels based on which channel a request comes from. The trust level determines how aggressively content is screened.
 
-## Trust Levels
+## How It Works
 
-| Trust Level | Meaning | Screening | SSRF Policy |
-|-------------|---------|-----------|-------------|
-| **Full** | Owner/admin channel | Permissive holster | Internal URLs allowed |
-| **Trusted** | Explicitly trusted user or group | Balanced holster | External URLs only |
-| **Public** | Public channel, anyone can message | Aggressive holster | External URLs only |
-| **Restricted** | Explicitly restricted | Aggressive holster | External URLs only |
-| **Unknown** | No registration (default) | Balanced holster | External URLs only |
+### Trust Chain
 
-## Check Current Trust Context
+1. **Aegis generates an Ed25519 identity keypair** on first start (stored in `.aegis/identity.key`)
+2. **The warden configures** `signing_pubkey` in `.aegis/config.toml` with the matching public key
+3. **Channel registrations must be signed** with the private key — unsigned requests are rejected
+4. **Aegis verifies the signature** and resolves trust level from config patterns — the registrant cannot claim a trust level, only report which channel it's on
 
-To see what trust level is active:
+The private key on disk is the root of trust. Without it, no channel can be registered.
+
+### Automatic Registration (OpenClaw Plugin)
+
+The `aegis-channel-trust` plugin (`plugins/aegis-channel-trust/`) fires on every incoming message:
+
+1. `message_received` hook fires (Telegram, Discord, web chat, etc.)
+2. Plugin reads the identity key from `.aegis/identity.key`
+3. Plugin signs `{channel, trust:"", ts, user}` with Ed25519 (keys alphabetically sorted)
+4. Plugin POSTs to `POST /aegis/register-channel` with the signed payload
+5. Aegis verifies signature, resolves trust from config patterns
+6. All subsequent proxy requests use that trust level for screening
+
+**Channel format:** `{platform}:{chatType}:{conversationId}`
+
+| Source | Channel Example | Trust Level |
+|--------|----------------|-------------|
+| Owner DM (Telegram) | `telegram:dm:owner` | full |
+| User DM (Telegram) | `telegram:dm:7965174951` | trusted |
+| Telegram group | `telegram:group:-1001234567` | public |
+| OpenClaw web chat | `openclaw:web:session123` | trusted |
+| CLI local | `cli:local:test` | full |
+| API direct | `api:direct:client1` | trusted |
+
+### Manual Registration (CLI)
+
+Use the CLI for testing or for channels outside the plugin:
+
+```bash
+# Register a channel with signed certificate
+aegis trust register openclaw:web:my-session
+aegis trust register telegram:dm:owner --user telegram:user:12345
+aegis trust register cli:local:test
+
+# Show current active channel + full registry
+aegis trust context
+
+# Show signing public key (for config setup)
+aegis trust pubkey
+```
+
+### API Registration (curl)
+
+For programmatic use — requires signing with the identity key:
 
 ```bash
 curl -s http://127.0.0.1:3141/aegis/channel-context
 ```
 
-## How It Works
+Unsigned POST requests to `/aegis/register-channel` are rejected when `signing_pubkey` is configured.
 
-1. The `aegis-channel-trust` plugin automatically registers your channel with Aegis when a message arrives
-2. Aegis maps the channel to a trust level based on the warden's `[trust]` configuration
-3. The trust level determines which holster preset is used for screening
-4. Higher trust = more permissive screening. Lower trust = stricter screening.
+## Trust Levels
 
-## Notes
+| Trust Level | Holster | Classifier | SSRF | Use Case |
+|-------------|---------|------------|------|----------|
+| **full** | Permissive | Advisory (log only) | Internal URLs allowed | Owner DM, CLI |
+| **trusted** | Balanced | Advisory (log only) | Blocked | Known users, web UI, API |
+| **public** | Aggressive | Blocking (quarantine) | Blocked | Telegram groups |
+| **restricted** | Aggressive | Blocking (quarantine) | Blocked | Unknown groups |
+| **unknown** | Balanced | Blocking (quarantine) | Blocked | No cert / legacy |
 
-- Trust levels are set by the warden's config, not by the agent
-- Channel registration happens at the plugin level — it cannot be manipulated by prompt injection
-- If Aegis is not running, the plugin fails silently — no impact on OpenClaw
+**Advisory vs Blocking classifier:** On trusted/full channels, the ProtectAI classifier logs detections but doesn't block. On public/unknown channels, it actively quarantines suspicious content.
+
+## Configuration
+
+Trust patterns are configured in `.aegis/config.toml`:
+
+```toml
+[trust]
+default_level = "unknown"
+signing_pubkey = "<hex Ed25519 pubkey from 'aegis trust pubkey'>"
+
+[[trust.channels]]
+pattern = "telegram:dm:owner"
+level = "full"
+
+[[trust.channels]]
+pattern = "telegram:dm:*"
+level = "trusted"
+
+[[trust.channels]]
+pattern = "telegram:group:*"
+level = "public"
+
+[[trust.channels]]
+pattern = "cli:local:*"
+level = "full"
+
+[[trust.channels]]
+pattern = "openclaw:web:*"
+level = "trusted"
+```
+
+Patterns support `*` wildcard per segment (e.g., `telegram:dm:*` matches any DM).
+
+## Security Model
+
+| Actor | Can register? | Why |
+|-------|--------------|-----|
+| Plugin with identity key | Yes | Has the private key, signature verifies |
+| `aegis trust register` CLI | Yes | Reads the same identity key |
+| Rogue process without key | No | Can't sign, Aegis rejects (HTTP 401) |
+| Remote attacker (injection) | No | No filesystem access to key file |
+| Unsigned curl request | No | `signing_pubkey` configured = signature required |
+
+The threat model protects against remote/software attacks. Local filesystem access to `.aegis/identity.key` is the trust boundary.
+
+## Cognitive Bridge Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/aegis/register-channel` | POST | Register channel with signed cert |
+| `/aegis/channel-context` | GET | Active channel + full registry |
+
+## Dashboard
+
+The **Channel Trust** tab shows:
+- Channel registry (all registered channels with request counts)
+- Per-channel screening history (click a channel row)
+- Trust badges (color-coded by trust level)
+- Active channel indicator


### PR DESCRIPTION
## Summary

Complete documentation for channel trust system across all docs:

- **SKILL.md** — Full rewrite: trust chain explanation, security model table, CLI commands, plugin auto-registration flow, config reference, dashboard info
- **README.md** — Added `aegis trust register/context/pubkey` to CLI reference
- **OPENCLAW_INTEGRATION.md** — New Channel Trust section: architecture diagram with plugin flow, trust levels table, plugin installation, security model, CLI testing, config reference
- **QUICKSTART.md** — Added trust commands to common commands section
- **CLAUDE.md** — Channel trust in request lifecycle, trust CLI commands, trust config section, cognitive bridge endpoints

## Test plan

- [x] All docs render correctly in markdown
- [x] CLI examples match actual command output
- [x] Config examples match actual `.aegis/config.toml`
- [x] Trust levels table matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)