### PR TITLE
fix: plugin maps 'webchat' channelId to openclaw:web:*

### DIFF
--- a/plugins/aegis-channel-trust/index.ts
+++ b/plugins/aegis-channel-trust/index.ts
@@ -178,7 +178,7 @@ const plugin: OpenClawPluginDefinition = {
       // Normalize platform name: "web" and "openclaw" both map to "openclaw"
       // so channel matches config pattern "openclaw:web:*"
       let platform = channelId;
-      if (channelId === "web" || channelId === "openclaw") {
+      if (channelId === "web" || channelId === "openclaw" || channelId === "webchat") {
         platform = "openclaw";
         chatType = "web";
       }


### PR DESCRIPTION
## Summary

OpenClaw web chat sends `channelId='webchat'` (not `'web'` or `'openclaw'`). The plugin only mapped `web` and `openclaw` → registered as `webchat:chat:default` → unknown trust.

Adds `webchat` to the platform normalization so it maps to `openclaw:web:<conversationId>` → trusted.

## Evidence

From Aegis logs:
```
channel context registered via cognitive bridge channel=webchat:chat:default trust_level=Unknown
ProtectAI classifier: MALICIOUS, fast-path quarantine prob=0.9880
SLM fast-layer quarantine (observe-only — forwarded anyway)
```

After fix: `webchat` → `openclaw:web:default` → trusted

🤖 Generated with [Claude Code](https://claude.com/claude-code)