### PR TITLE
feat: classifier advisory visibility in dashboard

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -23,6 +23,9 @@ use aegis_schemas::ReceiptType;
 use aegis_vault::scanner;
 use tracing::{debug, info};
 
+/// Global classifier advisory — set by screen_fast when advisory, consumed by build_verdict.
+static CLASSIFIER_ADVISORY: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
 // ---------------------------------------------------------------------------
 // Alert threshold
 // ---------------------------------------------------------------------------
@@ -396,6 +399,7 @@ impl SlmHookImpl {
             channel: None,
             channel_user: None,
             channel_trust_level: None,
+            classifier_advisory: None,
         };
 
         // Stamp channel trust from registered context (cognitive bridge)
@@ -403,6 +407,11 @@ impl SlmHookImpl {
             v.channel = trust.channel;
             v.channel_user = trust.user;
             v.channel_trust_level = Some(format!("{:?}", trust.trust_level).to_lowercase());
+        }
+
+        // Pick up classifier advisory if one was set during fast screening
+        if let Ok(mut advisory) = CLASSIFIER_ADVISORY.lock() {
+            v.classifier_advisory = advisory.take();
         }
 
         v
@@ -497,10 +506,20 @@ impl SlmHook for SlmHookImpl {
             .await;
 
             match result {
-                Ok(Some(screening_result)) => {
+                Ok((Some(screening_result), _advisory)) => {
                     Some(self.record_and_alert(&screening_result, content))
                 }
-                Ok(None) => None, // fast layers clean, needs deep SLM
+                Ok((None, advisory)) => {
+                    // Fast layers clean or advisory-only. Pass advisory to deep SLM path.
+                    if let Some(ref adv) = advisory {
+                        tracing::info!(advisory = %adv, "classifier advisory passed to deep SLM path");
+                    }
+                    // Store advisory for the deep SLM verdict to pick up
+                    if let Some(adv) = advisory {
+                        CLASSIFIER_ADVISORY.lock().ok().map(|mut a| *a = Some(adv));
+                    }
+                    None
+                }
                 Err(e) => {
                     tracing::warn!("fast screening task panicked: {e}");
                     None

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -677,6 +677,7 @@ function buildScreeningHtml(e){
   if(!heur_caught){
     h+='<div class="flow-node '+(cls_caught?'flow-node-caught':'flow-enrich')+'" style="flex:0 0 auto">Classifier<br><span class="flow-ms">'+(e.classifier_ms||'~5')+'ms</span>';
     if(cls_caught)h+='<br><span style="font-size:10px;color:#f85149;font-weight:600">CAUGHT</span>';
+    else if(e.classifier_advisory)h+='<br><span style="font-size:10px;color:#d29922;font-weight:600">advisory</span>';
     else h+='<br><span style="font-size:10px;color:#3fb950">clear</span>';
     h+='</div><div class="flow-arrow">\u2192</div>';
   }
@@ -703,7 +704,7 @@ function buildScreeningHtml(e){
   // Layer 2: Classifier
   h+='<div style="padding:8px 12px;background:#0d1117;border:1px solid '+(cls_caught?'#da3633':'#30363d')+';border-radius:6px">';
   h+='<div style="font-size:10px;font-weight:600;color:#a371f7;margin-bottom:4px">LAYER 2 — Classifier</div>';
-  h+=(heur_caught?'<div style="color:#8b949e;font-size:11px">Skipped</div>':cls_caught?'<div style="color:#f85149;font-size:11px;font-weight:600">CAUGHT</div>':'<div style="color:#3fb950;font-size:11px">Clear</div>');
+  h+=(heur_caught?'<div style="color:#8b949e;font-size:11px">Skipped</div>':cls_caught?'<div style="color:#f85149;font-size:11px;font-weight:600">CAUGHT</div>':e.classifier_advisory?'<div style="color:#d29922;font-size:11px;font-weight:600">ADVISORY</div>':'<div style="color:#3fb950;font-size:11px">Clear</div>');
   h+='</div>';
   // Layer 3: SLM
   h+='<div style="padding:8px 12px;background:#0d1117;border:1px solid '+((passA_caught||passB_caught)?'#da3633':'#30363d')+';border-radius:6px">';
@@ -816,6 +817,7 @@ function showSlmDetail(seq){
     h+='<div class="flow-node '+(cls_caught?'flow-node-caught':cls_ran?'flow-enrich':'flow-parse')+'" style="flex:0 0 auto">';
     h+='Classifier<br><span class="flow-ms">'+(cls_ran?e.classifier_ms+'ms':'~5ms')+'</span>';
     if(cls_caught)h+='<br><span style="font-size:10px;color:#f85149;font-weight:600">CAUGHT</span>';
+    else if(e.classifier_advisory)h+='<br><span style="font-size:10px;color:#d29922;font-weight:600">advisory</span>';
     else h+='<br><span style="font-size:10px;color:#3fb950">clear</span>';
     h+='</div><div class="flow-arrow">→</div>';
   }
@@ -862,6 +864,7 @@ function showSlmDetail(seq){
   h+='<div style="font-size:11px;font-weight:600;color:#a371f7;margin-bottom:6px">LAYER 2 — ProtectAI Classifier</div>';
   if(heur_caught){h+='<div style="color:#8b949e;font-size:12px">Skipped — heuristic already caught</div>';}
   else if(cls_caught){h+='<div style="color:#f85149;font-size:12px;font-weight:600">CAUGHT — high-confidence MALICIOUS</div>';}
+  else if(e.classifier_advisory){h+='<div style="color:#d29922;font-size:12px;font-weight:600">ADVISORY — '+escHtml(e.classifier_advisory)+'</div>';}
   else{h+='<div style="color:#3fb950;font-size:12px">Clear — classified as safe</div>';}
   h+='<div style="font-size:10px;color:#8b949e;margin-top:4px">'+(cls_ran?e.classifier_ms+'ms':'~5ms')+'</div>';
   h+='</div>';

--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -228,6 +228,7 @@ struct SlmScreeningEntry {
     channel: Option<String>,
     channel_user: Option<String>,
     channel_trust_level: Option<String>,
+    classifier_advisory: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -709,6 +710,10 @@ async fn api_slm(
                     channel,
                     channel_user,
                     channel_trust_level,
+                    classifier_advisory: detail
+                        .and_then(|d| d.get("classifier_advisory"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
                 });
             }
         }

--- a/adapter/aegis-proxy/src/middleware.rs
+++ b/adapter/aegis-proxy/src/middleware.rs
@@ -197,6 +197,10 @@ pub struct SlmVerdict {
     /// Resolved trust level for this request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_trust_level: Option<String>,
+    /// Classifier advisory: classifier flagged but trust level was advisory (not blocking).
+    /// Shows what the classifier detected even though the final decision was admit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classifier_advisory: Option<String>,
 }
 
 /// A detected pattern annotation with excerpt.

--- a/adapter/aegis-slm/src/loopback.rs
+++ b/adapter/aegis-slm/src/loopback.rs
@@ -97,12 +97,15 @@ pub fn screen_content(config: &LoopbackConfig, content: &str) -> ScreeningDecisi
 /// (returns None to let the SLM handle it) instead of quarantining.
 /// Set to false for trusted channels where the classifier may false-positive
 /// on legitimate orchestration text.
-pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profile: Option<&HolsterProfile>, classifier_blocking: bool) -> Option<ScreeningResult> {
+/// Returns (screening_result, classifier_advisory).
+/// - screening_result: Some if a fast layer caught a threat, None if clean/advisory
+/// - classifier_advisory: Some("prob=0.98") if classifier flagged but was in advisory mode
+pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profile: Option<&HolsterProfile>, classifier_blocking: bool) -> (Option<ScreeningResult>, Option<String>) {
     use std::time::Instant;
     let pipeline_start = Instant::now();
 
     if content.is_empty() {
-        return Some(ScreeningResult {
+        return (Some(ScreeningResult {
             decision: ScreeningDecision::Admit,
             enriched: None,
             holster: None,
@@ -111,7 +114,7 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
                 engine: config.engine.clone(),
                 ..Default::default()
             },
-        });
+        }), None);
     }
 
     // Classifier pre-filter
@@ -123,11 +126,13 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
         None
     };
 
+    let mut classifier_advisory: Option<String> = None;
+
     if let Some((true, prob)) = classifier_signal {
         if prob > 0.5 {
             if classifier_blocking {
                 info!(prob, "ProtectAI classifier: MALICIOUS, fast-path quarantine");
-                return Some(ScreeningResult {
+                return (Some(ScreeningResult {
                     decision: ScreeningDecision::Quarantine(format!(
                         "prompt_guard: MALICIOUS (prob={prob:.4})"
                     )),
@@ -139,11 +144,12 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
                         engine: "prompt-guard".to_string(),
                         ..Default::default()
                     },
-                });
+                }), None);
             } else {
                 // Advisory mode: classifier flagged it but trust level says don't block.
                 // Log and let the SLM make the final decision.
                 info!(prob, "ProtectAI classifier: suspicious (advisory, trusted channel — forwarding to SLM)");
+                classifier_advisory = Some(format!("prompt_guard: MALICIOUS (prob={prob:.4}) — advisory, trusted channel"));
             }
         }
     }
@@ -177,7 +183,7 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
                             "threat_score={} intent={:?}", enriched.threat_score, enriched.intent
                         )),
                     };
-                    return Some(ScreeningResult {
+                    return (Some(ScreeningResult {
                         decision,
                         enriched: Some(enriched),
                         holster: Some(holster_result),
@@ -188,14 +194,14 @@ pub fn screen_fast_layers(config: &LoopbackConfig, content: &str, holster_profil
                             engine: "heuristic".to_string(),
                             ..Default::default()
                         },
-                    });
+                    }), classifier_advisory);
                 }
             }
         }
     }
 
-    // Both fast layers clean — needs deep SLM analysis
-    None
+    // Fast layers clean (or advisory only) — needs deep SLM analysis
+    (None, classifier_advisory)
 }
 
 /// Run only the deep SLM layer (2-3s). Call only after screen_fast_layers returns None.


### PR DESCRIPTION
## Summary

When the ProtectAI classifier flags content on a **trusted** channel, the dashboard previously showed "Clear" — because advisory mode meant the classifier's finding was silently dropped. Now it shows **ADVISORY** in yellow, preserving the classifier's detection even when it didn't block.

## What changed

- `screen_fast_layers()` now returns `(Option<ScreeningResult>, Option<String>)` — the advisory string carries through to the verdict
- `SlmVerdict` gains `classifier_advisory` field (serialized to evidence receipts)
- Dashboard shows advisory state in 3 places:
  - Pipeline flow node: yellow "advisory" label
  - Layer 2 detail: "ADVISORY — prompt_guard: MALICIOUS (prob=0.98) — advisory, trusted channel"
  - Compact layer grid: yellow "ADVISORY" instead of green "Clear"

## Before/After

| State | Before | After |
|-------|--------|-------|
| Trusted channel, classifier flags | "Clear" (green) | "ADVISORY" (yellow) with prob |
| Public channel, classifier flags | "CAUGHT" (red) | "CAUGHT" (red) — unchanged |
| No classifier detection | "Clear" (green) | "Clear" (green) — unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)