### PR TITLE
fix(security): fail-closed on mutex poison in rate limiter and nonce registry

### DIFF
--- a/adapter/aegis-adapter/src/state.rs
+++ b/adapter/aegis-adapter/src/state.rs
@@ -81,13 +81,16 @@ impl AdapterState {
         self.evidence.chain_head().receipt_count
     }
 
-    /// Register a nonce for replay prevention. Returns true if new.
+    /// Register a nonce for replay prevention. Returns true if new (allowed).
+    /// Fails closed: if the mutex is poisoned, returns false (rejected)
+    /// to prevent replay attacks via panic-induced lock poisoning.
     pub fn register_nonce(&self, nonce: &str) -> bool {
-        if let Ok(mut registry) = self.nonce_registry.lock() {
-            registry.register(nonce)
-        } else {
-            // Lock poisoned — allow through (fail open)
-            true
+        match self.nonce_registry.lock() {
+            Ok(mut registry) => registry.register(nonce),
+            Err(_poisoned) => {
+                tracing::error!("nonce registry mutex poisoned — failing closed, rejecting request");
+                false
+            }
         }
     }
 

--- a/adapter/aegis-proxy/src/rate_limit.rs
+++ b/adapter/aegis-proxy/src/rate_limit.rs
@@ -82,8 +82,16 @@ impl RateLimiter {
     /// Check if a request from the given identity is allowed.
     ///
     /// Returns `Ok(())` if allowed, `Err(retry_after_secs)` if rate limited.
+    /// Fails closed: if the mutex is poisoned, rejects with a large retry-after
+    /// value to prevent bypass via panic-induced lock poisoning.
     pub fn check(&self, identity: &str) -> Result<(), f64> {
-        let mut buckets = self.buckets.lock().unwrap_or_else(|e| e.into_inner());
+        let mut buckets = match self.buckets.lock() {
+            Ok(guard) => guard,
+            Err(_poisoned) => {
+                tracing::error!("rate limiter mutex poisoned — failing closed");
+                return Err(60.0);
+            }
+        };
 
         let bucket = buckets
             .entry(identity.to_string())


### PR DESCRIPTION
## Summary
- Rate limiter: on mutex poison, returns `Err(60.0)` (reject with 60s retry) instead of silently admitting unlimited requests
- Nonce registry: on mutex poison, returns `false` (reject) instead of `true` (allow replay)
- Both log at ERROR level for operator visibility

## Test plan
- [x] All 178 tests pass across aegis-proxy and aegis-adapter
- [x] Existing rate limit and nonce tests unchanged — verify normal behavior unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)