### PR TITLE
fix(schemas): add BasisPoints newtype with [0,10000] validation

### DIFF
--- a/aegis-schemas/src/basis_points.rs
+++ b/aegis-schemas/src/basis_points.rs
@@ -1,0 +1,120 @@
+//! Basis points newtype — validated integer in [0, 10000].
+//!
+//! Per D2 and D13: all scores in integer basis points, never floats.
+//! 10000 = 100.00%, 8500 = 85.00%, 0 = 0.00%.
+//!
+//! Rejects values > 10000 at construction and deserialization time.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// Maximum valid basis points value (100.00%).
+pub const MAX_BASIS_POINTS: u32 = 10_000;
+
+/// A validated basis points value in [0, 10000].
+///
+/// Cannot be constructed with a value > 10000.
+/// Serializes as a plain u32 for wire compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BasisPoints(u32);
+
+impl BasisPoints {
+    /// Create a new BasisPoints value, returning None if > 10000.
+    pub fn new(value: u32) -> Option<Self> {
+        if value > MAX_BASIS_POINTS {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+
+    /// Create a BasisPoints value, clamping to [0, 10000].
+    pub fn clamped(value: u32) -> Self {
+        Self(value.min(MAX_BASIS_POINTS))
+    }
+
+    /// Get the raw u32 value.
+    pub fn value(self) -> u32 {
+        self.0
+    }
+
+    /// Zero basis points.
+    pub const ZERO: Self = Self(0);
+
+    /// Maximum basis points (10000 = 100%).
+    pub const MAX: Self = Self(MAX_BASIS_POINTS);
+}
+
+impl fmt::Display for BasisPoints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Serialize for BasisPoints {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BasisPoints {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = u32::deserialize(deserializer)?;
+        BasisPoints::new(value).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "basis points value {value} exceeds maximum {MAX_BASIS_POINTS}"
+            ))
+        })
+    }
+}
+
+impl Default for BasisPoints {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_values() {
+        assert!(BasisPoints::new(0).is_some());
+        assert!(BasisPoints::new(5000).is_some());
+        assert!(BasisPoints::new(10000).is_some());
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        assert!(BasisPoints::new(10001).is_none());
+        assert!(BasisPoints::new(u32::MAX).is_none());
+    }
+
+    #[test]
+    fn clamped() {
+        assert_eq!(BasisPoints::clamped(99999).value(), 10000);
+        assert_eq!(BasisPoints::clamped(5000).value(), 5000);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let bp = BasisPoints::new(8500).unwrap();
+        let json = serde_json::to_string(&bp).unwrap();
+        assert_eq!(json, "8500");
+        let deserialized: BasisPoints = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, bp);
+    }
+
+    #[test]
+    fn deserialize_rejects_overflow() {
+        let result: Result<BasisPoints, _> = serde_json::from_str("10001");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_max_u32() {
+        let result: Result<BasisPoints, _> = serde_json::from_str("4294967295");
+        assert!(result.is_err());
+    }
+}

--- a/aegis-schemas/src/claim.rs
+++ b/aegis-schemas/src/claim.rs
@@ -2,6 +2,7 @@
 //!
 //! All scores in integer basis points. No floats in signed data.
 
+use crate::BasisPoints;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -19,8 +20,8 @@ pub struct Claim {
     /// Bot fingerprint of the attester (lowercase hex)
     pub attester_id: String,
 
-    /// Confidence in basis points (0-10000)
-    pub confidence_bp: u32,
+    /// Confidence in basis points (0-10000), validated at deserialization
+    pub confidence_bp: BasisPoints,
 
     /// Temporal scope of this claim
     pub temporal_scope: TemporalScope,
@@ -33,7 +34,7 @@ pub struct Claim {
 
     /// Computed by quarantine validator, basis points (0-10000)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub confabulation_score_bp: Option<u32>,
+    pub confabulation_score_bp: Option<BasisPoints>,
 
     /// Computed by quarantine temporal coherence check
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/aegis-schemas/src/lib.rs
+++ b/aegis-schemas/src/lib.rs
@@ -1,9 +1,11 @@
+pub mod basis_points;
 pub mod claim;
 pub mod config;
 pub mod enterprise;
 pub mod receipt;
 pub mod trustmark;
 
+pub use basis_points::BasisPoints;
 pub use claim::Claim;
 pub use config::{
     BODY_SIZE_CAP_MB, CheckMode, EnforcementConfig, RateLimitConfig, SlmReceiptDetail,

--- a/aegis-schemas/src/trustmark.rs
+++ b/aegis-schemas/src/trustmark.rs
@@ -3,6 +3,7 @@
 //! All scores are integer basis points (0-10000). No floats in signed data.
 //! 8500 = 85.00%.
 
+use crate::BasisPoints;
 use serde::{Deserialize, Serialize};
 
 /// TRUSTMARK score — 6-dimensional weighted sum.
@@ -10,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrustmarkScore {
     /// Overall score in basis points [0, 10000]
-    pub score_bp: u32,
+    pub score_bp: BasisPoints,
 
     /// Per-dimension breakdown (all in basis points)
     pub dimensions: TrustmarkDimensions,
@@ -27,17 +28,17 @@ pub struct TrustmarkScore {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrustmarkDimensions {
     /// Does this bot reliably relay mesh messages? Weight: 0.15
-    pub relay_reliability: u32,
+    pub relay_reliability: BasisPoints,
     /// Is SOUL.md intact, no unauthorized changes? Weight: 0.25
-    pub persona_integrity: u32,
+    pub persona_integrity: BasisPoints,
     /// Is the evidence chain unbroken? Weight: 0.20
-    pub chain_integrity: u32,
+    pub chain_integrity: BasisPoints,
     /// How active is this bot? Weight: 0.10
-    pub contribution_volume: u32,
+    pub contribution_volume: BasisPoints,
     /// Is activity consistent over time? Weight: 0.15
-    pub temporal_consistency: u32,
+    pub temporal_consistency: BasisPoints,
     /// Are credentials properly secured? Weight: 0.15
-    pub vault_hygiene: u32,
+    pub vault_hygiene: BasisPoints,
 }
 
 /// Trust tier (D14)

--- a/tests/contract/src/lib.rs
+++ b/tests/contract/src/lib.rs
@@ -257,6 +257,7 @@ mod receipt_tests {
 mod claim_tests {
     use aegis_crypto::rfc8785;
     use aegis_schemas::claim::{Claim, ClaimType, TemporalScope};
+    use aegis_schemas::BasisPoints;
     use uuid::Uuid;
 
     fn sample_claim() -> Claim {
@@ -265,7 +266,7 @@ mod claim_tests {
             claim_type: ClaimType::Lore,
             namespace: "b/lore".to_string(),
             attester_id: "abc123def456".to_string(),
-            confidence_bp: 8500, // 85.00% in basis points
+            confidence_bp: BasisPoints::new(8500).unwrap(), // 85.00% in basis points
             temporal_scope: TemporalScope {
                 start_ms: 1740000000000,
                 end_ms: None,
@@ -339,39 +340,40 @@ mod claim_tests {
 mod trustmark_tests {
     use aegis_crypto::rfc8785;
     use aegis_schemas::trustmark::{Tier, TrustmarkDimensions, TrustmarkScore};
+    use aegis_schemas::BasisPoints;
 
     #[test]
     fn trustmark_round_trip() {
         let score = TrustmarkScore {
-            score_bp: 7500, // 75.00%
+            score_bp: BasisPoints::new(7500).unwrap(), // 75.00%
             dimensions: TrustmarkDimensions {
-                relay_reliability: 8000,
-                persona_integrity: 9000,
-                chain_integrity: 10000,
-                contribution_volume: 5000,
-                temporal_consistency: 7000,
-                vault_hygiene: 6000,
+                relay_reliability: BasisPoints::new(8000).unwrap(),
+                persona_integrity: BasisPoints::new(9000).unwrap(),
+                chain_integrity: BasisPoints::new(10000).unwrap(),
+                contribution_volume: BasisPoints::new(5000).unwrap(),
+                temporal_consistency: BasisPoints::new(7000).unwrap(),
+                vault_hygiene: BasisPoints::new(6000).unwrap(),
             },
             tier: Tier::Tier2,
             computed_at_ms: 1740000000000,
         };
         let json = serde_json::to_string(&score).unwrap();
         let deserialized: TrustmarkScore = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.score_bp, 7500);
+        assert_eq!(deserialized.score_bp, BasisPoints::new(7500).unwrap());
         assert_eq!(deserialized, score); // PartialEq now works (no floats!)
     }
 
     #[test]
     fn trustmark_canonical_deterministic() {
         let score = TrustmarkScore {
-            score_bp: 5000,
+            score_bp: BasisPoints::new(5000).unwrap(),
             dimensions: TrustmarkDimensions {
-                relay_reliability: 5000,
-                persona_integrity: 5000,
-                chain_integrity: 5000,
-                contribution_volume: 5000,
-                temporal_consistency: 5000,
-                vault_hygiene: 5000,
+                relay_reliability: BasisPoints::new(5000).unwrap(),
+                persona_integrity: BasisPoints::new(5000).unwrap(),
+                chain_integrity: BasisPoints::new(5000).unwrap(),
+                contribution_volume: BasisPoints::new(5000).unwrap(),
+                temporal_consistency: BasisPoints::new(5000).unwrap(),
+                vault_hygiene: BasisPoints::new(5000).unwrap(),
             },
             tier: Tier::Tier1,
             computed_at_ms: 1740000000000,
@@ -384,14 +386,14 @@ mod trustmark_tests {
     #[test]
     fn trustmark_no_floats() {
         let score = TrustmarkScore {
-            score_bp: 8500,
+            score_bp: BasisPoints::new(8500).unwrap(),
             dimensions: TrustmarkDimensions {
-                relay_reliability: 8000,
-                persona_integrity: 9000,
-                chain_integrity: 10000,
-                contribution_volume: 5000,
-                temporal_consistency: 7000,
-                vault_hygiene: 6000,
+                relay_reliability: BasisPoints::new(8000).unwrap(),
+                persona_integrity: BasisPoints::new(9000).unwrap(),
+                chain_integrity: BasisPoints::new(10000).unwrap(),
+                contribution_volume: BasisPoints::new(5000).unwrap(),
+                temporal_consistency: BasisPoints::new(7000).unwrap(),
+                vault_hygiene: BasisPoints::new(6000).unwrap(),
             },
             tier: Tier::Tier3,
             computed_at_ms: 1740000000000,


### PR DESCRIPTION
## Summary
- New `BasisPoints` newtype in aegis-schemas with validated [0, 10000] range
- Custom serde: rejects values > 10000 at deserialization
- Applied to: `TrustmarkScore.score_bp`, all `TrustmarkDimensions` fields, `Claim.confidence_bp`, `Claim.confabulation_score_bp`
- Wire-compatible: serializes as plain u32

## Test plan
- [x] All 62 workspace test suites pass (590+ tests)
- [x] 6 new BasisPoints unit tests (valid, overflow, clamped, serde roundtrip, deserialize reject)
- [x] Contract tests updated to use BasisPoints::new()

🤖 Generated with [Claude Code](https://claude.com/claude-code)