### PR TITLE
docs(cluster): document 2/3 quorum is not Byzantine-fault tolerant

### DIFF
--- a/cluster/botawiki/src/lib.rs
+++ b/cluster/botawiki/src/lib.rs
@@ -14,5 +14,7 @@ pub mod write;
 
 // TODO(D2): Confirm per-type claim payload schemas
 // TODO(D22): Confirm quarantine quorum (3 validators, 2/3 approve)
+// WARNING: 2/3 quorum is crash-fault tolerant only, NOT Byzantine-safe.
+// See cluster/evaluator/src/lib.rs for details. Consider 4+ validators.
 // TODO(D28): Confirm confabulation score threshold (0.5 default)
 // TODO(D29): Confirm source diversity minimums per namespace

--- a/cluster/evaluator/src/lib.rs
+++ b/cluster/evaluator/src/lib.rs
@@ -3,6 +3,18 @@
 //! Attestation package builder + evaluator selection (3 per request)
 //! Vote aggregation: 2/3 must approve for Tier 3 admission
 //! Accountability linkage: evaluator TRUSTMARK penalized if admittee misbehaves (D20)
+//!
+//! # Security limitation
+//!
+//! The 2/3 quorum (2 of 3 validators) is crash-fault tolerant but NOT
+//! Byzantine-fault tolerant. BFT requires strictly > 2/3 honest nodes
+//! (i.e., 3f+1 total to tolerate f faults). With 3 evaluators, a single
+//! compromised evaluator + one colluding = full quorum control.
+//!
+//! For Byzantine safety, increase the evaluator set to 4+ nodes
+//! (requiring 3/4 approval) or 7+ nodes (requiring 5/7 approval).
+//! Until then, this module provides Tier 3 admission ceremony with
+//! crash-fault tolerance only.
 
 pub mod accountability;
 pub mod attestation;


### PR DESCRIPTION
## Summary
- Documented security limitation: 2/3 quorum (2 of 3 validators) is crash-fault tolerant only
- Added detailed explanation with BFT requirements (3f+1 nodes)
- Added warning in botawiki quarantine referencing evaluator docs
- Recommended upgrading to 4+ validators for Byzantine safety

## Test plan
- [x] Documentation-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)