### PR TITLE
fix(memory): replace blocking I/O with async tokio::fs

### DIFF
--- a/adapter/aegis-memory/src/monitor.rs
+++ b/adapter/aegis-memory/src/monitor.rs
@@ -144,7 +144,7 @@ impl MemoryMonitor {
 
                     // Read old and new content for screening
                     let old_content = None; // We don't store old content, just hashes
-                    let new_content = std::fs::read_to_string(path).ok();
+                    let new_content = tokio::fs::read_to_string(path).await.ok();
 
                     let screen_result = self.screener.screen(
                         &path.to_string_lossy(),
@@ -199,7 +199,7 @@ impl MemoryMonitor {
                     Ok(state) => {
                         changes_detected += 1;
 
-                        let content = std::fs::read_to_string(path).ok();
+                        let content = tokio::fs::read_to_string(path).await.ok();
                         let screen_result =
                             self.screener
                                 .screen(&path.to_string_lossy(), None, content.as_deref());


### PR DESCRIPTION
## Summary
- Replace `std::fs::read_to_string` with `tokio::fs::read_to_string` in `MemoryMonitor::check_cycle()` (two call sites)
- These calls were blocking the tokio runtime thread inside an async function, potentially starving other tasks

## Test plan
- [x] `cargo test -p aegis-memory` passes (23 tests)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)