### PR TITLE
fix(barrier): prevent panic on clock regression in now_ms()

### DIFF
--- a/adapter/aegis-barrier/src/watcher.rs
+++ b/adapter/aegis-barrier/src/watcher.rs
@@ -189,7 +189,7 @@ impl FileWatcher {
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before Unix epoch")
+        .unwrap_or_default()
         .as_millis() as u64
 }
 


### PR DESCRIPTION
## Summary
- Replace `.expect("system clock before Unix epoch")` with `.unwrap_or_default()` in `now_ms()`
- If the system clock is before Unix epoch, returns duration 0 instead of panicking

## Test plan
- [x] `cargo test -p aegis-barrier` passes (231 tests)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)