### PR TITLE
feat(config): add config validation at startup

### DIFF
--- a/adapter/aegis-adapter/src/config.rs
+++ b/adapter/aegis-adapter/src/config.rs
@@ -376,6 +376,24 @@ impl AdapterConfig {
         Ok(config)
     }
 
+    /// Validate configuration values at startup.
+    /// Returns an error string describing the first invalid field found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.proxy.rate_limit_per_minute == 0 {
+            return Err("proxy.rate_limit_per_minute must be > 0".to_string());
+        }
+        if self.proxy.burst_size == 0 {
+            return Err("proxy.burst_size must be > 0".to_string());
+        }
+        if self.proxy.max_body_size == 0 {
+            return Err("proxy.max_body_size must be > 0".to_string());
+        }
+        if self.slm.slm_timeout_secs == 0 {
+            return Err("slm.slm_timeout_secs must be > 0".to_string());
+        }
+        Ok(())
+    }
+
     /// Load from default location (.aegis/config.toml) or return defaults.
     pub fn load_or_default() -> Self {
         let default_path = PathBuf::from(".aegis").join("config.toml");
@@ -409,5 +427,39 @@ mod tests {
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: AdapterConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.proxy.listen_addr, config.proxy.listen_addr);
+    }
+
+    #[test]
+    fn default_config_validates() {
+        let config = AdapterConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn zero_rate_limit_fails_validation() {
+        let mut config = AdapterConfig::default();
+        config.proxy.rate_limit_per_minute = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn zero_burst_size_fails_validation() {
+        let mut config = AdapterConfig::default();
+        config.proxy.burst_size = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn zero_max_body_size_fails_validation() {
+        let mut config = AdapterConfig::default();
+        config.proxy.max_body_size = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn zero_slm_timeout_fails_validation() {
+        let mut config = AdapterConfig::default();
+        config.slm.slm_timeout_secs = 0;
+        assert!(config.validate().is_err());
     }
 }

--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -95,6 +95,9 @@ pub enum StartupError {
 pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result<(), StartupError> {
     let start_time = Instant::now();
 
+    // 0. Validate configuration
+    config.validate().map_err(StartupError::Config)?;
+
     // 1. Determine operating mode
     let mode = mode_override.unwrap_or_else(|| config.mode.clone().into());
     let mode_controller = Arc::new(ModeController::new(mode));

--- a/adapter/aegis-proxy/src/config.rs
+++ b/adapter/aegis-proxy/src/config.rs
@@ -227,6 +227,21 @@ impl ProxyConfig {
         }
     }
 
+    /// Validate configuration values at startup.
+    /// Returns an error string describing the first invalid field found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.rate_limit_per_minute == 0 {
+            return Err("rate_limit_per_minute must be > 0".to_string());
+        }
+        if self.rate_limit_burst == 0 {
+            return Err("rate_limit_burst must be > 0".to_string());
+        }
+        if self.max_body_size == 0 {
+            return Err("max_body_size must be > 0".to_string());
+        }
+        Ok(())
+    }
+
     /// Create an enforcement config (blocks on violations).
     pub fn enforce(upstream_url: &str, listen_addr: &str) -> Self {
         Self {
@@ -332,5 +347,32 @@ mod tests {
     #[test]
     fn from_url_unknown_defaults_to_compat() {
         assert_eq!(Provider::from_url("https://my-llm-server.example.com"), Provider::OpenAiCompat);
+    }
+
+    #[test]
+    fn default_proxy_config_validates() {
+        let cfg = ProxyConfig::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn zero_rate_limit_fails_validation() {
+        let mut cfg = ProxyConfig::default();
+        cfg.rate_limit_per_minute = 0;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn zero_burst_fails_validation() {
+        let mut cfg = ProxyConfig::default();
+        cfg.rate_limit_burst = 0;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn zero_max_body_size_fails_validation() {
+        let mut cfg = ProxyConfig::default();
+        cfg.max_body_size = 0;
+        assert!(cfg.validate().is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Add `validate()` methods to `ProxyConfig` and `AdapterConfig` that reject zero values for rate limits, burst size, max body size, and SLM timeout.
- Call `config.validate()` at server startup before any subsystem initialization.
- Added unit tests for all validation checks in both config modules.

## Test plan
- [x] `cargo test -p aegis-adapter --lib config` passes (8 tests)
- [x] `cargo test -p aegis-proxy --lib config` passes (16 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)