### PR TITLE
Add webhook alerting for observation mode

### DIFF
--- a/adapter/aegis-adapter/Cargo.toml
+++ b/adapter/aegis-adapter/Cargo.toml
@@ -31,6 +31,7 @@ anyhow.workspace = true
 rand.workspace = true
 hex.workspace = true
 notify.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/adapter/aegis-adapter/src/config.rs
+++ b/adapter/aegis-adapter/src/config.rs
@@ -47,6 +47,11 @@ pub struct AdapterConfig {
     /// Channel trust configuration
     #[serde(default)]
     pub trust: TrustSection,
+
+    /// Optional webhook URL for critical alerts.
+    /// When set, critical alerts are POSTed here in addition to the SSE dashboard stream.
+    #[serde(default)]
+    pub webhook_url: Option<String>,
 }
 
 /// Trust configuration — channel-based access control + context observability.
@@ -349,6 +354,7 @@ impl Default for AdapterConfig {
             rate_limit: RateLimitConfig::default(),
             data_dir: default_data_dir(),
             trust: TrustSection::default(),
+            webhook_url: None,
         }
     }
 }

--- a/adapter/aegis-adapter/src/lib.rs
+++ b/adapter/aegis-adapter/src/lib.rs
@@ -22,6 +22,7 @@ pub mod mode;
 pub mod replay;
 pub mod server;
 pub mod state;
+pub mod webhook;
 
 /// Adapter operating mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -131,6 +131,12 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
     let (alert_tx, _alert_rx) =
         tokio::sync::broadcast::channel::<aegis_dashboard::DashboardAlert>(32);
 
+    // 4a. Optionally spawn webhook alerter for critical alerts
+    if let Some(ref webhook_url) = config.webhook_url {
+        let alerter = crate::webhook::WebhookAlerter::new(webhook_url.clone());
+        alerter.spawn(alert_tx.subscribe());
+    }
+
     let chain_head = recorder.chain_head();
     info!(
         seq = chain_head.head_seq,

--- a/adapter/aegis-adapter/src/webhook.rs
+++ b/adapter/aegis-adapter/src/webhook.rs
@@ -1,0 +1,97 @@
+//! Webhook alerter — sends critical alerts to an external URL.
+//!
+//! When `webhook_url` is configured, a background task subscribes to the
+//! dashboard alert broadcast channel and POSTs each alert as JSON.
+//! Errors are logged but never block the main pipeline.
+
+use std::time::Duration;
+
+use aegis_dashboard::DashboardAlert;
+use tokio::sync::broadcast;
+use tracing::{info, warn};
+
+/// Webhook alerter that sends `DashboardAlert` payloads to an HTTP endpoint.
+pub struct WebhookAlerter {
+    url: String,
+    client: reqwest::Client,
+}
+
+impl WebhookAlerter {
+    /// Create a new WebhookAlerter targeting the given URL.
+    pub fn new(url: String) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_default();
+        Self { url, client }
+    }
+
+    /// Send a single alert. Logs errors but never fails.
+    pub async fn send(&self, alert: &DashboardAlert) {
+        match self.client.post(&self.url).json(alert).send().await {
+            Ok(resp) => {
+                if !resp.status().is_success() {
+                    warn!(
+                        status = %resp.status(),
+                        url = %self.url,
+                        "webhook alert returned non-success status"
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    url = %self.url,
+                    error = %e,
+                    "webhook alert failed"
+                );
+            }
+        }
+    }
+
+    /// Spawn a background task that subscribes to the alert broadcast channel
+    /// and forwards each alert to the webhook URL.
+    pub fn spawn(self, mut rx: broadcast::Receiver<DashboardAlert>) {
+        tokio::spawn(async move {
+            info!(url = %self.url, "webhook alerter started");
+            loop {
+                match rx.recv().await {
+                    Ok(alert) => {
+                        self.send(&alert).await;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(skipped = n, "webhook alerter lagged, skipped alerts");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        info!("webhook alerter shutting down (channel closed)");
+                        break;
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webhook_alerter_creation() {
+        let alerter = WebhookAlerter::new("https://example.com/webhook".to_string());
+        assert_eq!(alerter.url, "https://example.com/webhook");
+    }
+
+    #[tokio::test]
+    async fn webhook_alerter_handles_unreachable_url() {
+        // Sending to a non-routable address should log but not panic
+        let alerter = WebhookAlerter::new("http://192.0.2.1:1/webhook".to_string());
+        let alert = DashboardAlert {
+            ts_ms: 1234567890,
+            kind: "test".to_string(),
+            message: "test alert".to_string(),
+            receipt_seq: 1,
+        };
+        // This should complete without panicking (timeout will fire)
+        alerter.send(&alert).await;
+    }
+}


### PR DESCRIPTION
## Summary
- Added `webhook_url: Option<String>` to `AdapterConfig`
- Created `WebhookAlerter` struct that POSTs `DashboardAlert` JSON with 5s timeout
- Spawns alongside the broadcast channel on startup when configured
- Errors logged but never block

## Test plan
- [x] All 47 aegis-adapter tests pass
- [x] New tests verify alerter creation and graceful handling of unreachable URLs

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)