### PR TITLE
style: apply cargo fmt to fix CI

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -310,7 +310,8 @@ impl BarrierHook for BarrierHookImpl {
             match self.protected_files.lock() {
                 Ok(mgr) => {
                     if mgr.is_critical(path) {
-                        let reason = format!("request targets critical protected path: {}", req_info.path);
+                        let reason =
+                            format!("request targets critical protected path: {}", req_info.path);
                         self.record_and_alert(
                             &req_info.method,
                             &req_info.path,
@@ -341,8 +342,10 @@ impl BarrierHook for BarrierHookImpl {
                         for entry in mgr.list_all() {
                             let upper_name = entry.pattern.to_uppercase();
                             if body_upper.contains(&upper_name) {
-                                let reason =
-                                    format!("request body references protected file: {}", entry.pattern);
+                                let reason = format!(
+                                    "request body references protected file: {}",
+                                    entry.pattern
+                                );
                                 self.record_and_alert(
                                     &req_info.method,
                                     &req_info.path,

--- a/adapter/aegis-adapter/src/replay.rs
+++ b/adapter/aegis-adapter/src/replay.rs
@@ -158,11 +158,8 @@ impl NonceRegistry {
         }
         let to_remove = self.nonces.len() - target;
         // Collect entries sorted by insertion time (oldest first)
-        let mut entries: Vec<(String, Instant)> = self
-            .nonces
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect();
+        let mut entries: Vec<(String, Instant)> =
+            self.nonces.iter().map(|(k, v)| (k.clone(), *v)).collect();
         entries.sort_by_key(|(_, t)| *t);
         for (key, _) in entries.into_iter().take(to_remove) {
             self.nonces.remove(&key);

--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -174,7 +174,10 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                 }
             }
         });
-        info!("automatic rollup trigger started (check every 60s, threshold={})", aegis_evidence::recorder::DEFAULT_ROLLUP_THRESHOLD);
+        info!(
+            "automatic rollup trigger started (check every 60s, threshold={})",
+            aegis_evidence::recorder::DEFAULT_ROLLUP_THRESHOLD
+        );
     }
 
     // 5. Create shared state

--- a/adapter/aegis-adapter/src/state.rs
+++ b/adapter/aegis-adapter/src/state.rs
@@ -43,7 +43,9 @@ impl SecurityState {
         match self.nonce_registry.lock() {
             Ok(mut registry) => registry.register(nonce),
             Err(_poisoned) => {
-                tracing::error!("nonce registry mutex poisoned — failing closed, rejecting request");
+                tracing::error!(
+                    "nonce registry mutex poisoned — failing closed, rejecting request"
+                );
                 false
             }
         }

--- a/adapter/aegis-proxy/src/config.rs
+++ b/adapter/aegis-proxy/src/config.rs
@@ -127,17 +127,11 @@ impl Provider {
     /// `url` crate. Handles `scheme://host:port/path` and `scheme://host/path`.
     fn extract_host(url: &str) -> Option<String> {
         // Strip scheme
-        let after_scheme = url
-            .find("://")
-            .map(|i| &url[i + 3..])
-            .unwrap_or(url);
+        let after_scheme = url.find("://").map(|i| &url[i + 3..]).unwrap_or(url);
         // Strip path
         let host_port = after_scheme.split('/').next().unwrap_or(after_scheme);
         // Strip userinfo (user:pass@host)
-        let host_port = host_port
-            .rsplit('@')
-            .next()
-            .unwrap_or(host_port);
+        let host_port = host_port.rsplit('@').next().unwrap_or(host_port);
         // Strip port — but be careful with IPv6 [::1]:port
         let host = if host_port.starts_with('[') {
             // IPv6: [::1]:port or [::1]
@@ -157,10 +151,7 @@ impl Provider {
 
     /// Extract the port number from a URL string, if present.
     fn extract_port(url: &str) -> Option<u16> {
-        let after_scheme = url
-            .find("://")
-            .map(|i| &url[i + 3..])
-            .unwrap_or(url);
+        let after_scheme = url.find("://").map(|i| &url[i + 3..]).unwrap_or(url);
         let host_port = after_scheme.split('/').next().unwrap_or(after_scheme);
         // For IPv6 [::1]:port
         if host_port.starts_with('[') {
@@ -315,38 +306,71 @@ mod tests {
 
     #[test]
     fn from_url_detects_anthropic() {
-        assert_eq!(Provider::from_url("https://api.anthropic.com"), Provider::Anthropic);
-        assert_eq!(Provider::from_url("https://api.anthropic.com/v1/messages"), Provider::Anthropic);
+        assert_eq!(
+            Provider::from_url("https://api.anthropic.com"),
+            Provider::Anthropic
+        );
+        assert_eq!(
+            Provider::from_url("https://api.anthropic.com/v1/messages"),
+            Provider::Anthropic
+        );
     }
 
     #[test]
     fn from_url_detects_openai() {
-        assert_eq!(Provider::from_url("https://api.openai.com"), Provider::OpenAi);
-        assert_eq!(Provider::from_url("https://api.openai.com/v1/chat/completions"), Provider::OpenAi);
+        assert_eq!(
+            Provider::from_url("https://api.openai.com"),
+            Provider::OpenAi
+        );
+        assert_eq!(
+            Provider::from_url("https://api.openai.com/v1/chat/completions"),
+            Provider::OpenAi
+        );
     }
 
     #[test]
     fn from_url_detects_ollama() {
-        assert_eq!(Provider::from_url("http://localhost:11434"), Provider::Ollama);
-        assert_eq!(Provider::from_url("http://127.0.0.1:11434/api/chat"), Provider::Ollama);
+        assert_eq!(
+            Provider::from_url("http://localhost:11434"),
+            Provider::Ollama
+        );
+        assert_eq!(
+            Provider::from_url("http://127.0.0.1:11434/api/chat"),
+            Provider::Ollama
+        );
     }
 
     #[test]
     fn from_url_detects_openrouter() {
-        assert_eq!(Provider::from_url("https://openrouter.ai/api/v1"), Provider::OpenAiCompat);
+        assert_eq!(
+            Provider::from_url("https://openrouter.ai/api/v1"),
+            Provider::OpenAiCompat
+        );
     }
 
     #[test]
     fn from_url_rejects_spoofed_domains() {
         // These should NOT match Anthropic — they are attacker-controlled domains
-        assert_eq!(Provider::from_url("https://evil-anthropic.com"), Provider::OpenAiCompat);
-        assert_eq!(Provider::from_url("https://notanthropic.com"), Provider::OpenAiCompat);
-        assert_eq!(Provider::from_url("https://anthropic.com.evil.com"), Provider::OpenAiCompat);
+        assert_eq!(
+            Provider::from_url("https://evil-anthropic.com"),
+            Provider::OpenAiCompat
+        );
+        assert_eq!(
+            Provider::from_url("https://notanthropic.com"),
+            Provider::OpenAiCompat
+        );
+        assert_eq!(
+            Provider::from_url("https://anthropic.com.evil.com"),
+            Provider::OpenAiCompat
+        );
     }
 
     #[test]
     fn from_url_unknown_defaults_to_compat() {
-        assert_eq!(Provider::from_url("https://my-llm-server.example.com"), Provider::OpenAiCompat);
+        assert_eq!(
+            Provider::from_url("https://my-llm-server.example.com"),
+            Provider::OpenAiCompat
+        );
     }
 
     #[test]

--- a/aegis-crypto/src/bip39.rs
+++ b/aegis-crypto/src/bip39.rs
@@ -132,8 +132,8 @@ pub fn generate_mnemonic() -> Result<String, Bip39Error> {
     let mut entropy = [0u8; 32];
     rand::rngs::OsRng.fill_bytes(&mut entropy);
 
-    let mnemonic = Mnemonic::from_entropy(&entropy)
-        .map_err(|e| Bip39Error::DerivationFailed(e.to_string()));
+    let mnemonic =
+        Mnemonic::from_entropy(&entropy).map_err(|e| Bip39Error::DerivationFailed(e.to_string()));
 
     // Zeroize entropy immediately after use
     entropy.zeroize();
@@ -195,12 +195,11 @@ pub fn slip0010_derive(seed: &[u8; 64], path: &[u32]) -> Result<[u8; 32], Bip39E
                 "SLIP-0010 Ed25519 requires all hardened indices".to_string(),
             ));
         }
-        let mut mac = HmacSha512::new_from_slice(&chain_code)
-            .map_err(|e| {
-                key.zeroize();
-                chain_code.zeroize();
-                Bip39Error::DerivationFailed(e.to_string())
-            })?;
+        let mut mac = HmacSha512::new_from_slice(&chain_code).map_err(|e| {
+            key.zeroize();
+            chain_code.zeroize();
+            Bip39Error::DerivationFailed(e.to_string())
+        })?;
         mac.update(&[0x00]);
         mac.update(&key);
         mac.update(&index.to_be_bytes());

--- a/cluster/trustmark/src/scoring.rs
+++ b/cluster/trustmark/src/scoring.rs
@@ -761,7 +761,11 @@ mod tests {
         assert!(schema.dimensions.contribution_volume.value() <= 10000);
 
         // Perfect signals should produce a high score
-        assert!(schema.score_bp.value() > 9000, "perfect signals should yield >9000bp, got {}", schema.score_bp.value());
+        assert!(
+            schema.score_bp.value() > 9000,
+            "perfect signals should yield >9000bp, got {}",
+            schema.score_bp.value()
+        );
     }
 
     #[test]

--- a/tests/contract/src/lib.rs
+++ b/tests/contract/src/lib.rs
@@ -256,8 +256,8 @@ mod receipt_tests {
 #[cfg(test)]
 mod claim_tests {
     use aegis_crypto::rfc8785;
-    use aegis_schemas::claim::{Claim, ClaimType, TemporalScope};
     use aegis_schemas::BasisPoints;
+    use aegis_schemas::claim::{Claim, ClaimType, TemporalScope};
     use uuid::Uuid;
 
     fn sample_claim() -> Claim {
@@ -339,8 +339,8 @@ mod claim_tests {
 #[cfg(test)]
 mod trustmark_tests {
     use aegis_crypto::rfc8785;
-    use aegis_schemas::trustmark::{Tier, TrustmarkDimensions, TrustmarkScore};
     use aegis_schemas::BasisPoints;
+    use aegis_schemas::trustmark::{Tier, TrustmarkDimensions, TrustmarkScore};
 
     #[test]
     fn trustmark_round_trip() {
@@ -517,12 +517,12 @@ mod crypto_tests {
 #[cfg(test)]
 mod adversarial_tests {
     use aegis_crypto::rfc8785;
+    use aegis_schemas::BasisPoints;
     use aegis_schemas::receipt::{
         GENESIS_PREV_HASH, Receipt, ReceiptContext, ReceiptCore, ReceiptType, RollupDetail,
         RollupHistogram, generate_blinding_nonce,
     };
     use aegis_schemas::trustmark::{Tier, TrustmarkDimensions, TrustmarkScore};
-    use aegis_schemas::BasisPoints;
     use std::collections::HashMap;
     use uuid::Uuid;
 
@@ -559,13 +559,34 @@ mod adversarial_tests {
         let json = serde_json::to_value(&context).unwrap();
 
         // None fields must be absent, not present as null
-        assert!(json.get("action").is_none(), "action must be omitted, not null");
-        assert!(json.get("subject").is_none(), "subject must be omitted, not null");
-        assert!(json.get("trigger").is_none(), "trigger must be omitted, not null");
-        assert!(json.get("outcome").is_none(), "outcome must be omitted, not null");
-        assert!(json.get("detail").is_none(), "detail must be omitted, not null");
-        assert!(json.get("enterprise").is_none(), "enterprise must be omitted, not null");
-        assert!(json.get("enforcement_mode").is_none(), "enforcement_mode must be omitted, not null");
+        assert!(
+            json.get("action").is_none(),
+            "action must be omitted, not null"
+        );
+        assert!(
+            json.get("subject").is_none(),
+            "subject must be omitted, not null"
+        );
+        assert!(
+            json.get("trigger").is_none(),
+            "trigger must be omitted, not null"
+        );
+        assert!(
+            json.get("outcome").is_none(),
+            "outcome must be omitted, not null"
+        );
+        assert!(
+            json.get("detail").is_none(),
+            "detail must be omitted, not null"
+        );
+        assert!(
+            json.get("enterprise").is_none(),
+            "enterprise must be omitted, not null"
+        );
+        assert!(
+            json.get("enforcement_mode").is_none(),
+            "enforcement_mode must be omitted, not null"
+        );
 
         // blinding_nonce must always be present
         assert!(json.get("blinding_nonce").is_some());
@@ -595,7 +616,10 @@ mod adversarial_tests {
         // Canonicalize twice and verify determinism
         let canonical1 = rfc8785::canonicalize(&core).unwrap();
         let canonical2 = rfc8785::canonicalize(&core).unwrap();
-        assert_eq!(canonical1, canonical2, "canonical JSON must be deterministic with unicode bot_id");
+        assert_eq!(
+            canonical1, canonical2,
+            "canonical JSON must be deterministic with unicode bot_id"
+        );
 
         // Round-trip must preserve the unicode
         let json = serde_json::to_string(&core).unwrap();
@@ -608,7 +632,8 @@ mod adversarial_tests {
         // Test BasisPoints at exact boundaries: 0, 1, 9999, 10000
         let boundaries = [0u32, 1, 9999, 10000];
         for &val in &boundaries {
-            let bp = BasisPoints::new(val).unwrap_or_else(|| panic!("BasisPoints({val}) should be valid"));
+            let bp = BasisPoints::new(val)
+                .unwrap_or_else(|| panic!("BasisPoints({val}) should be valid"));
             assert_eq!(bp.value(), val);
 
             // Serialize and deserialize
@@ -649,7 +674,7 @@ mod adversarial_tests {
         let rollup = RollupDetail {
             seq_start: 1,
             seq_end: 100,
-            receipt_count: 100,  // claims 100 receipts
+            receipt_count: 100, // claims 100 receipts
             merkle_root: "d".repeat(64),
             head_hash: "e".repeat(64),
             histogram: RollupHistogram {


### PR DESCRIPTION
## Summary
- Applied `cargo fmt --all` to fix formatting issues introduced across PRs #123-#152
- No functional changes — whitespace and line wrapping only
- 8 files affected: hooks.rs, replay.rs, server.rs, state.rs, config.rs, bip39.rs, scoring.rs, contract tests

## Test plan
- [x] `cargo fmt --all -- --check` passes clean
- [x] `cargo clippy --workspace --all-targets` — no errors
- [x] All workspace tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)