### PR TITLE
fix(ci): resolve clippy warnings for CI pass

### DIFF
--- a/adapter/aegis-evidence/src/recorder.rs
+++ b/adapter/aegis-evidence/src/recorder.rs
@@ -7,6 +7,7 @@
 //!   1. chain_state
 //!   2. store
 //!   3. last_rollup_seq
+//!
 //! Acquiring locks out of order risks deadlock.
 
 use std::path::Path;

--- a/adapter/aegis-proxy/src/config.rs
+++ b/adapter/aegis-proxy/src/config.rs
@@ -140,7 +140,7 @@ impl Provider {
                 .map(|i| &host_port[1..i])
                 .unwrap_or(host_port)
         } else {
-            host_port.rsplit(':').last().unwrap_or(host_port)
+            host_port.rsplit(':').next_back().unwrap_or(host_port)
         };
         if host.is_empty() {
             None
@@ -380,6 +380,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn zero_rate_limit_fails_validation() {
         let mut cfg = ProxyConfig::default();
         cfg.rate_limit_per_minute = 0;
@@ -387,6 +388,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn zero_burst_fails_validation() {
         let mut cfg = ProxyConfig::default();
         cfg.rate_limit_burst = 0;
@@ -394,6 +396,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn zero_max_body_size_fails_validation() {
         let mut cfg = ProxyConfig::default();
         cfg.max_body_size = 0;


### PR DESCRIPTION
## Summary
- Fixed `doc_lazy_continuation` in evidence recorder doc comment
- Fixed `double_ended_iterator_last` — use `next_back()` instead of `last()` on rsplit
- Allowed `field_reassign_with_default` on 3 validation test functions

## Test plan
- [x] `cargo clippy` with exact CI flags passes clean
- [x] `cargo fmt --all -- --check` passes clean
- [x] All workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)