### PR TITLE
fix(ci): correct contract test package name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run contract tests
-        run: cargo test -p contract-tests
-        continue-on-error: true  # package may not exist yet
+        run: cargo test -p aegis-contract-tests
 
   # ── Build Release Binaries ────────────────────────────────────
   build:


### PR DESCRIPTION
## Summary
- Fixed `cargo test -p contract-tests` → `cargo test -p aegis-contract-tests`
- Removed `continue-on-error: true` since the package exists

## Test plan
- [x] `cargo test -p aegis-contract-tests` passes locally
- [x] Check & Lint job already passes (PR #154)

🤖 Generated with [Claude Code](https://claude.com/claude-code)