### PR TITLE
fix: remove global ACTIVE_CHANNEL writes, use per-request trust

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -525,12 +525,9 @@ impl SlmHookImpl {
             classifier_advisory: None,
         };
 
-        // Stamp channel trust from registered context (cognitive bridge)
-        if let Some(trust) = aegis_proxy::cognitive_bridge::get_registered_channel_trust() {
-            v.channel = trust.channel;
-            v.channel_user = trust.user;
-            v.channel_trust_level = Some(format!("{:?}", trust.trust_level).to_lowercase());
-        }
+        // Channel trust is stamped by the `stamp_trust` closure in proxy.rs
+        // AFTER build_verdict returns — no need to read from the global here.
+        // The global ACTIVE_CHANNEL races under concurrent load.
 
         // Classifier advisory passed through function parameter (not a global)
         v.classifier_advisory = classifier_advisory;

--- a/adapter/aegis-proxy/src/cognitive_bridge.rs
+++ b/adapter/aegis-proxy/src/cognitive_bridge.rs
@@ -318,7 +318,12 @@ struct ChannelContextResponse {
 static CHANNEL_REGISTRY: std::sync::RwLock<ChannelRegistry> =
     std::sync::RwLock::new(ChannelRegistry::new());
 
-/// Active channel — the most recently registered channel (used for proxy trust resolution).
+/// Active channel — the most recently registered channel.
+///
+/// DEPRECATED: This global is a race condition under concurrent load.
+/// Per-request trust is carried in `RequestInfo::channel_trust` and stamped
+/// onto SLM verdicts by the `stamp_trust` closure in proxy.rs.
+/// New code should NOT read from this global.
 static ACTIVE_CHANNEL: std::sync::RwLock<Option<aegis_schemas::ChannelTrust>> =
     std::sync::RwLock::new(None);
 
@@ -353,6 +358,10 @@ pub struct ChannelRecord {
 }
 
 /// Get the current active channel trust context.
+///
+/// DEPRECATED: This reads from a global that races under concurrent load.
+/// Use `RequestInfo::channel_trust` instead — it carries per-request context.
+#[deprecated(note = "Use per-request RequestInfo::channel_trust instead")]
 pub fn get_registered_channel_trust() -> Option<aegis_schemas::ChannelTrust> {
     ACTIVE_CHANNEL.read().ok()?.clone()
 }
@@ -472,10 +481,9 @@ async fn register_channel_handler(
         registered: true,
     };
 
-    // Store as active channel
-    if let Ok(mut ctx) = ACTIVE_CHANNEL.write() {
-        *ctx = Some(trust);
-    }
+    // NOTE: Previously wrote to ACTIVE_CHANNEL here, but that global races
+    // under concurrent load. Per-request trust is carried in RequestInfo::channel_trust.
+    // The channel registry below is still maintained for observability (dashboard).
 
     // Update channel registry
     let now_ms = crate::middleware::now_ms();


### PR DESCRIPTION
## Summary
- Stop writing to the global `ACTIVE_CHANNEL` in `register_channel_handler()` — it races under concurrent load
- Deprecate `get_registered_channel_trust()` with `#[deprecated]` attribute
- Remove the redundant call in `hooks.rs::build_verdict()` — trust is already stamped by `stamp_trust` closure in proxy.rs

## Test plan
- [x] `cargo test -p aegis-proxy -p aegis-adapter` passes
- [ ] Verify under concurrent load that per-request trust context is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)