### PR TITLE
fix(ci): allow deprecated get_registered_channel_trust in barrier watcher

### DIFF
--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -621,6 +621,9 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                         // Trusted/Full → allow change, update manifest (warden or authorized agent)
                         // Public/Unknown/Restricted → potential prompt injection, block/alert
                         // No channel → no active session, treat as suspicious
+                        // Background watcher has no per-request context — read global
+                        // channel trust (best-effort for barrier decisions).
+                        #[allow(deprecated)]
                         let channel_trust =
                             aegis_proxy::cognitive_bridge::get_registered_channel_trust();
                         let is_trusted_channel = channel_trust


### PR DESCRIPTION
## Summary
- Added `#[allow(deprecated)]` to barrier watcher's use of `get_registered_channel_trust()`
- Background watcher has no per-request context — global read is the only option here
- Fixes clippy `-D warnings` treating the deprecation as error

## Test plan
- [x] `cargo clippy` with exact CI flags passes clean
- [x] `cargo fmt --all -- --check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)