### PR TITLE
feat(pipeline): add request_id to ReceiptContext and PipelineReceipt

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -59,6 +59,7 @@ fn record_receipt(
     outcome: &str,
     detail: Option<serde_json::Value>,
     alert_tx: Option<&tokio::sync::broadcast::Sender<crate::state::DashboardAlert>>,
+    request_id: Option<&str>,
 ) {
     let context = aegis_schemas::ReceiptContext {
         blinding_nonce: aegis_schemas::receipt::generate_blinding_nonce(),
@@ -69,6 +70,7 @@ fn record_receipt(
         outcome: Some(outcome.to_string()),
         detail,
         enterprise: None,
+        request_id: request_id.map(|s| s.to_string()),
     };
     if let Err(e) = recorder.record(receipt_type.clone(), context) {
         tracing::warn!(receipt_type = ?receipt_type, action = %action, "failed to record receipt: {e}");
@@ -128,6 +130,7 @@ impl EvidenceHook for EvidenceHookImpl {
                 &outcome,
                 None,
                 Some(&self.alert_tx),
+                Some(&req_info.request_id),
             );
 
             debug!(
@@ -159,6 +162,7 @@ impl EvidenceHook for EvidenceHookImpl {
                 &outcome,
                 None,
                 Some(&self.alert_tx),
+                Some(&req_info.request_id),
             );
 
             debug!(
@@ -192,6 +196,7 @@ impl EvidenceHook for EvidenceHookImpl {
                 &outcome,
                 None,
                 Some(&self.alert_tx),
+                None,
             );
 
             // Vault detection also gets an explicit alert (not gated by is_critical)
@@ -380,6 +385,7 @@ impl BarrierHookImpl {
             reason,
             None,
             Some(&self.alert_tx),
+            None,
         );
     }
 }
@@ -568,6 +574,7 @@ impl SlmHookImpl {
             &outcome_str,
             detail,
             Some(&self.alert_tx),
+            None,
         );
 
         // Push explicit alert on quarantine/reject (SLM alerts always push)

--- a/adapter/aegis-evidence/src/chain.rs
+++ b/adapter/aegis-evidence/src/chain.rs
@@ -154,6 +154,7 @@ mod tests {
             outcome: Some("pass".to_string()),
             detail: None,
             enterprise: None,
+            request_id: None,
         }
     }
 

--- a/adapter/aegis-evidence/src/merkle.rs
+++ b/adapter/aegis-evidence/src/merkle.rs
@@ -129,6 +129,7 @@ mod tests {
             outcome: None,
             detail: None,
             enterprise: None,
+            request_id: None,
         }
     }
 

--- a/adapter/aegis-evidence/src/recorder.rs
+++ b/adapter/aegis-evidence/src/recorder.rs
@@ -149,6 +149,7 @@ impl EvidenceRecorder {
             outcome: Some(outcome.to_string()),
             detail: None,
             enterprise: None,
+            request_id: None,
         };
         self.record(receipt_type, context)
     }
@@ -197,6 +198,7 @@ impl EvidenceRecorder {
             outcome: Some("completed".to_string()),
             detail: Some(serde_json::to_value(&rollup_detail)?),
             enterprise: None,
+            request_id: None,
         };
 
         let rollup_receipt = chain::create_receipt(

--- a/adapter/aegis-evidence/src/store.rs
+++ b/adapter/aegis-evidence/src/store.rs
@@ -348,6 +348,7 @@ mod tests {
             outcome: None,
             detail: None,
             enterprise: None,
+            request_id: None,
         }
     }
 

--- a/adapter/aegis-proxy/src/pipeline.rs
+++ b/adapter/aegis-proxy/src/pipeline.rs
@@ -14,6 +14,8 @@ pub struct PipelineReceipt {
     pub action: String,
     pub outcome: String,
     pub detail: Option<serde_json::Value>,
+    /// Pipeline request ID — always set from PipelineState.
+    pub request_id: String,
 }
 
 /// Result of a vault scan (request or response direction).
@@ -174,6 +176,7 @@ impl PipelineState {
                     vault.secrets_found.join(", ")
                 ),
                 detail: None,
+                request_id: self.request_id_str(),
             });
         }
 
@@ -187,6 +190,7 @@ impl PipelineState {
                 &body_hash[..16.min(body_hash.len())]
             ),
             detail: None,
+            request_id: self.request_id_str(),
         });
 
         // 3. Barrier check
@@ -201,6 +205,7 @@ impl PipelineState {
                     .clone()
                     .unwrap_or_else(|| barrier.decision.clone()),
                 detail: None,
+                request_id: self.request_id_str(),
             });
         }
 
@@ -228,6 +233,7 @@ impl PipelineState {
                     .verdict
                     .as_ref()
                     .and_then(|v| serde_json::to_value(v).ok()),
+                request_id: self.request_id_str(),
             });
         }
 
@@ -255,6 +261,7 @@ impl PipelineState {
                     .verdict
                     .as_ref()
                     .and_then(|v| serde_json::to_value(v).ok()),
+                request_id: self.request_id_str(),
             });
         }
 
@@ -270,6 +277,7 @@ impl PipelineState {
                     resp_duration_ms.unwrap_or(0)
                 ),
                 detail: None,
+                request_id: self.request_id_str(),
             });
         }
 
@@ -286,6 +294,7 @@ impl PipelineState {
                     vault.secrets_found.join(", ")
                 ),
                 detail: None,
+                request_id: self.request_id_str(),
             });
         }
 

--- a/aegis-schemas/src/receipt.rs
+++ b/aegis-schemas/src/receipt.rs
@@ -90,6 +90,12 @@ pub struct ReceiptContext {
     /// Enterprise fields — nested object inside context, NOT top-level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enterprise: Option<EnterpriseContext>,
+
+    /// Pipeline request ID (UUID v7) — links all receipts from the same HTTP request.
+    /// Enables cross-referencing evidence receipts with dashboard traffic entries.
+    /// None for receipts not generated from the request pipeline (e.g., memory monitor).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 /// Enterprise fields inside ReceiptContext (D1: nested, not flattened).

--- a/aegis-schemas/tests/receipt_enforcement_mode_test.rs
+++ b/aegis-schemas/tests/receipt_enforcement_mode_test.rs
@@ -11,6 +11,7 @@ fn enforcement_mode_field_omitted_when_none() {
         outcome: None,
         detail: None,
         enterprise: None,
+        request_id: None,
     };
     let json = serde_json::to_value(&ctx).unwrap();
     assert!(
@@ -30,6 +31,7 @@ fn enforcement_mode_field_present_when_set() {
         outcome: None,
         detail: None,
         enterprise: None,
+        request_id: None,
     };
     let json = serde_json::to_value(&ctx).unwrap();
     assert_eq!(json["enforcement_mode"], "observe");

--- a/tests/contract/src/lib.rs
+++ b/tests/contract/src/lib.rs
@@ -37,6 +37,7 @@ mod receipt_tests {
             outcome: Some("success".to_string()),
             detail: Some(serde_json::json!({"model": "gpt-4", "tokens": 150})),
             enterprise: None,
+            request_id: None,
         }
     }
 
@@ -120,6 +121,7 @@ mod receipt_tests {
             outcome: None,
             detail: None,
             enterprise: None,
+            request_id: None,
         };
         let json = serde_json::to_value(&context).unwrap();
         // These fields should NOT be present (omitted, not null)
@@ -154,6 +156,7 @@ mod receipt_tests {
                 compliance_extensions: None,
                 fleet_aggregate: None,
             }),
+            request_id: None,
         };
         let json = serde_json::to_value(&context).unwrap();
         // Enterprise is a nested object, not flattened
@@ -555,6 +558,7 @@ mod adversarial_tests {
             outcome: None,
             detail: None,
             enterprise: None,
+            request_id: None,
         };
         let json = serde_json::to_value(&context).unwrap();
 
@@ -705,5 +709,44 @@ mod adversarial_tests {
             seq_range_count, rollup.receipt_count,
             "seq range matches receipt_count (this is the primary invariant)"
         );
+    }
+
+    #[test]
+    fn receipt_context_request_id_round_trip() {
+        let ctx = ReceiptContext {
+            blinding_nonce: generate_blinding_nonce(),
+            enforcement_mode: None,
+            action: None,
+            subject: None,
+            trigger: None,
+            outcome: None,
+            detail: None,
+            enterprise: None,
+            request_id: Some("01234567-89ab-cdef-0123-456789abcdef".to_string()),
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert!(json.contains("request_id"));
+        let parsed: ReceiptContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.request_id,
+            Some("01234567-89ab-cdef-0123-456789abcdef".to_string())
+        );
+    }
+
+    #[test]
+    fn receipt_context_request_id_omitted_when_none() {
+        let ctx = ReceiptContext {
+            blinding_nonce: generate_blinding_nonce(),
+            enforcement_mode: None,
+            action: None,
+            subject: None,
+            trigger: None,
+            outcome: None,
+            detail: None,
+            enterprise: None,
+            request_id: None,
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert!(!json.contains("request_id"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `request_id: Option<String>` field to `ReceiptContext` in `aegis-schemas` with `skip_serializing_if` for clean omission when None
- Thread `request_id` parameter through the centralized `record_receipt()` helper in hooks.rs — evidence hooks pass `Some(&req_info.request_id)`, hooks without request context pass `None`
- Add `request_id: String` field to `PipelineReceipt`, set from `PipelineState::request_id_str()` on every receipt produced by `to_receipts()`
- Fix all `ReceiptContext` construction sites across the workspace (recorder, chain, merkle, store, tests) to include `request_id: None`
- Add contract tests for `request_id` round-trip serialization and omission-when-None behavior

This is the final step of the RequestPipeline refactoring — enables cross-referencing evidence receipts with dashboard traffic entries via a shared UUID v7 request ID.

## Test plan

- [x] `cargo build --workspace` — no compile errors
- [x] `cargo test --workspace` — all 580+ tests pass (including 2 new request_id tests)
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy` with CI flags — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)