### PR TITLE
Wire request_id into traffic recording

### DIFF
--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -908,7 +908,8 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                   model: Option<&str>,
                   context: Option<&str>,
                   slm_detail: Option<serde_json::Value>,
-                  response_screen: Option<serde_json::Value>| {
+                  response_screen: Option<serde_json::Value>,
+                  request_id: Option<&str>| {
                 let (slm_dur, slm_action, slm_score) = match slm_verdict {
                     Some(v) => (
                         Some(v.screening_ms),
@@ -935,7 +936,11 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                     slm_detail,
                     response_screen,
                 );
-                ts.last_id()
+                let entry_id = ts.last_id();
+                if let (Some(id), Some(rid)) = (entry_id, request_id) {
+                    ts.update_request_id(id, rid);
+                }
+                entry_id
             },
         )
     };

--- a/adapter/aegis-dashboard/src/traffic.rs
+++ b/adapter/aegis-dashboard/src/traffic.rs
@@ -240,3 +240,73 @@ impl TrafficStore {
         self.entries.read().ok()?.back().map(|e| e.id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> TrafficStore {
+        TrafficStore::new(100)
+    }
+
+    fn record_dummy(store: &TrafficStore) {
+        store.record(
+            "POST",
+            "/v1/chat/completions",
+            200,
+            b"{\"messages\":[]}",
+            b"{\"choices\":[]}",
+            42,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_record_and_get() {
+        let store = make_store();
+        record_dummy(&store);
+        assert_eq!(store.len(), 1);
+        let entry = store.get(1).unwrap();
+        assert_eq!(entry.method, "POST");
+        assert_eq!(entry.path, "/v1/chat/completions");
+        assert_eq!(entry.status, 200);
+        assert_eq!(entry.request_id, None);
+    }
+
+    #[test]
+    fn test_update_request_id() {
+        let store = make_store();
+        record_dummy(&store);
+        let id = store.last_id().unwrap();
+        assert_eq!(store.get(id).unwrap().request_id, None);
+
+        store.update_request_id(id, "01964a2b-7c00-7def-8000-000000000001");
+        let entry = store.get(id).unwrap();
+        assert_eq!(
+            entry.request_id.as_deref(),
+            Some("01964a2b-7c00-7def-8000-000000000001")
+        );
+    }
+
+    #[test]
+    fn test_ring_buffer_eviction() {
+        let store = TrafficStore::new(2);
+        record_dummy(&store);
+        record_dummy(&store);
+        record_dummy(&store);
+        assert_eq!(store.len(), 2);
+        // First entry (id=1) should be evicted
+        assert!(store.get(1).is_none());
+        assert!(store.get(2).is_some());
+        assert!(store.get(3).is_some());
+    }
+}

--- a/adapter/aegis-proxy/src/proxy.rs
+++ b/adapter/aegis-proxy/src/proxy.rs
@@ -93,6 +93,7 @@ pub type TrafficRecorder = dyn Fn(
         Option<&str>,                    // context (OpenClaw)
         Option<serde_json::Value>,       // slm_detail
         Option<serde_json::Value>,       // response_screen
+        Option<&str>,                    // request_id (pipeline UUID v7)
     ) -> Option<u64>
     + Send
     + Sync;
@@ -339,6 +340,7 @@ async fn recording_middleware(
                 context,
                 slm_v.as_ref().and_then(|v| serde_json::to_value(v).ok()),
                 None, // no response screening on early rejections
+                None, // no request_id on early rejections
             );
         }
     }
@@ -1343,6 +1345,7 @@ async fn forward_request(
                                 None
                             }
                         }),
+                    Some(stream_request_id.as_str()),
                 )
             } else {
                 None
@@ -1547,6 +1550,7 @@ async fn forward_request(
             response_screen_result
                 .as_ref()
                 .and_then(|r| serde_json::to_value(r).ok()),
+            Some(req_info.request_id.as_str()),
         )
     } else {
         None


### PR DESCRIPTION
## Summary
- Add `request_id: Option<&str>` as the last parameter to the `TrafficRecorder` callback type
- Pass pipeline request_id from non-streaming and streaming handlers; pass `None` for early rejections
- In `server.rs`, the closure calls `update_request_id()` after `record()` to link traffic entries to their pipeline UUID v7
- Add unit tests for `TrafficStore`: basic record/get, `update_request_id`, and ring-buffer eviction

## Test plan
- [x] `cargo test --workspace` — all tests pass including 3 new traffic store tests
- [x] `cargo fmt --all` — no formatting changes
- [x] `cargo clippy` with CI flags — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)