### PR TITLE
Add dashboard join endpoint for traffic receipts

### DIFF
--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -93,6 +93,7 @@ pub fn routes(state: Arc<DashboardSharedState>) -> Router {
         .route("/api/slm", get(api_slm))
         .route("/api/traffic", get(api_traffic))
         .route("/api/traffic/{id}", get(api_traffic_detail))
+        .route("/api/traffic/{id}/receipts", get(api_traffic_receipts))
         .route("/api/trust", get(api_trust))
         .route("/api/trust/add", post(api_trust_add))
         .route("/api/trust/remove", post(api_trust_remove))
@@ -914,6 +915,58 @@ async fn api_traffic_detail(
             }))
         }
         None => Json(serde_json::json!({"error": "not found"})),
+    }
+}
+
+/// GET /dashboard/api/traffic/{id}/receipts — evidence receipts linked to a traffic entry by request_id.
+async fn api_traffic_receipts(
+    State(state): State<Arc<DashboardSharedState>>,
+    Path(id): Path<u64>,
+) -> Json<serde_json::Value> {
+    // 1. Get traffic entry
+    let entry = match state.traffic.get(id) {
+        Some(e) => e,
+        None => return Json(serde_json::json!({"error": "traffic entry not found"})),
+    };
+
+    // 2. Get request_id
+    let request_id = match entry.request_id {
+        Some(ref rid) => rid.clone(),
+        None => {
+            return Json(serde_json::json!({
+                "receipts": [],
+                "note": "no request_id on this traffic entry",
+            }));
+        }
+    };
+
+    // 3. Query evidence chain for matching receipts
+    match state.evidence.get_by_request_id(&request_id) {
+        Ok(receipts) => {
+            let receipt_summaries: Vec<serde_json::Value> = receipts
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "id": r.core.id,
+                        "seq": r.core.seq,
+                        "receipt_type": format!("{:?}", r.core.receipt_type),
+                        "bot_id": r.core.bot_id,
+                        "ts_ms": r.core.ts_ms,
+                        "action": r.context.action,
+                        "outcome": r.context.outcome,
+                        "subject": r.context.subject,
+                        "trigger": r.context.trigger,
+                    })
+                })
+                .collect();
+            Json(serde_json::json!({
+                "request_id": request_id,
+                "receipts": receipt_summaries,
+            }))
+        }
+        Err(e) => Json(serde_json::json!({
+            "error": format!("evidence query failed: {e}"),
+        })),
     }
 }
 

--- a/adapter/aegis-evidence/src/recorder.rs
+++ b/adapter/aegis-evidence/src/recorder.rs
@@ -256,6 +256,17 @@ impl EvidenceRecorder {
             .unwrap_or_else(|_| chain::init_genesis())
     }
 
+    /// Get all receipts matching a request_id.
+    ///
+    /// Delegates to [`EvidenceStore::get_receipts_by_request_id`].
+    pub fn get_by_request_id(&self, request_id: &str) -> Result<Vec<Receipt>, EvidenceError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| EvidenceError::StoreError(format!("lock poisoned: {e}")))?;
+        store.get_receipts_by_request_id(request_id)
+    }
+
     /// Get the bot ID (public key hex).
     pub fn bot_id(&self) -> &str {
         &self.bot_id
@@ -368,6 +379,40 @@ mod tests {
         assert_eq!(partial.len(), 3);
         assert_eq!(partial[0].core.seq, 2);
         assert_eq!(partial[2].core.seq, 4);
+    }
+
+    #[test]
+    fn recorder_get_by_request_id() {
+        let key = generate_keypair();
+        let recorder = EvidenceRecorder::new_in_memory(key).unwrap();
+
+        let rid = "01964a2b-7c00-7def-8000-000000000042";
+
+        // Record with request_id
+        let ctx = ReceiptContext {
+            blinding_nonce: generate_blinding_nonce(),
+            enforcement_mode: None,
+            action: Some("chat_completion".to_string()),
+            subject: None,
+            trigger: None,
+            outcome: Some("forwarded".to_string()),
+            detail: None,
+            enterprise: None,
+            request_id: Some(rid.to_string()),
+        };
+        recorder.record(ReceiptType::ApiCall, ctx).unwrap();
+
+        // Record without request_id
+        recorder
+            .record_simple(ReceiptType::SlmAnalysis, "screen", "admitted")
+            .unwrap();
+
+        let matched = recorder.get_by_request_id(rid).unwrap();
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].context.request_id.as_deref(), Some(rid));
+
+        let empty = recorder.get_by_request_id("nonexistent").unwrap();
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/adapter/aegis-evidence/src/store.rs
+++ b/adapter/aegis-evidence/src/store.rs
@@ -224,6 +224,37 @@ impl EvidenceStore {
         Ok(())
     }
 
+    /// Get all receipts matching a request_id in their context JSON.
+    ///
+    /// Uses SQLite's JSON_EXTRACT to search the `context_json` column.
+    /// Full table scan (no index on JSON field) — acceptable for per-adapter volumes.
+    pub fn get_receipts_by_request_id(
+        &self,
+        request_id: &str,
+    ) -> Result<Vec<Receipt>, EvidenceError> {
+        let mut stmt = self.db.prepare(
+            "SELECT core_json, context_json FROM receipts WHERE JSON_EXTRACT(context_json, '$.request_id') = ?1 ORDER BY seq ASC",
+        )?;
+
+        let rows = stmt.query_map(params![request_id], |row| {
+            let core_json: String = row.get(0)?;
+            let context_json: String = row.get(1)?;
+            Ok((core_json, context_json))
+        })?;
+
+        let mut receipts = Vec::new();
+        for row in rows {
+            let (core_json, context_json) = row?;
+            let core: ReceiptCore = serde_json::from_str(&core_json)
+                .map_err(|e| EvidenceError::SerializationError(e.to_string()))?;
+            let context: ReceiptContext = serde_json::from_str(&context_json)
+                .map_err(|e| EvidenceError::SerializationError(e.to_string()))?;
+            receipts.push(Receipt { core, context });
+        }
+
+        Ok(receipts)
+    }
+
     /// Total receipt count.
     pub fn get_receipt_count(&self) -> Result<u64, EvidenceError> {
         let count: i64 = self
@@ -489,6 +520,36 @@ mod tests {
         let backup_store = EvidenceStore::open(&backup_path).unwrap();
         assert_eq!(backup_store.get_receipt_count().unwrap(), 3);
         assert!(backup_store.integrity_check().is_ok());
+    }
+
+    #[test]
+    fn get_receipts_by_request_id() {
+        let store = EvidenceStore::open_in_memory().unwrap();
+        let key = generate_keypair();
+        let bot_id = ed25519::fingerprint_hex(&key.verifying_key());
+        let mut state = init_genesis();
+
+        let rid = "01964a2b-7c00-7def-8000-000000000001";
+
+        // Record 2 receipts with request_id, 1 without
+        for i in 0..3 {
+            let mut ctx = make_context();
+            if i < 2 {
+                ctx.request_id = Some(rid.to_string());
+            }
+            let r = create_receipt(&key, &bot_id, ReceiptType::ApiCall, ctx, &state).unwrap();
+            state = advance_chain_state(&state, &r);
+            store.append_receipt(&r, &state).unwrap();
+        }
+
+        let matched = store.get_receipts_by_request_id(rid).unwrap();
+        assert_eq!(matched.len(), 2);
+        assert_eq!(matched[0].core.seq, 1);
+        assert_eq!(matched[1].core.seq, 2);
+
+        // Non-existent request_id returns empty
+        let empty = store.get_receipts_by_request_id("nonexistent").unwrap();
+        assert!(empty.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `GET /dashboard/api/traffic/{id}/receipts` endpoint that joins a traffic entry to its evidence receipts via `request_id`
- Add `EvidenceStore::get_receipts_by_request_id()` using SQLite `JSON_EXTRACT` to query the `context_json` column
- Expose through `EvidenceRecorder::get_by_request_id()` with proper mutex locking
- Returns receipt summaries (id, seq, type, action, outcome, timestamps) or appropriate messages for missing entries / no request_id

## Test plan
- [x] `cargo test --workspace` — all tests pass including 2 new tests (store + recorder level)
- [x] `cargo fmt --all` — no formatting changes
- [x] `cargo clippy` with CI flags — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)