### PR TITLE
fix(slm): strip /v1 suffix from server_url to prevent double path

### DIFF
--- a/adapter/aegis-slm/src/engine/openai_compat.rs
+++ b/adapter/aegis-slm/src/engine/openai_compat.rs
@@ -68,8 +68,12 @@ impl OpenAiCompatEngine {
             .build()
             .expect("failed to build reqwest blocking client");
 
+        // Normalize: strip trailing /v1 or /v1/ if present — we append it ourselves.
+        let cleaned = base_url.trim_end_matches('/');
+        let cleaned = cleaned.strip_suffix("/v1").unwrap_or(cleaned);
+
         Self {
-            url: base_url.trim_end_matches('/').to_string(),
+            url: cleaned.to_string(),
             model: model.to_string(),
             client,
         }


### PR DESCRIPTION
## Summary
- Strip trailing `/v1` from server_url in OpenAI-compat engine constructor
- Prevents double `/v1/v1/chat/completions` path when config has `server_url = "http://host:port/v1"`
- LM Studio and other servers reject the doubled path

## Test plan
- [x] 76 SLM tests pass
- [x] Verified with LM Studio: `http://127.0.0.1:1234/v1` now correctly maps to `/v1/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)