### PR TITLE
release: v0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/AEGIS-GB/neural-commons"


### PR DESCRIPTION
## Fixes since v0.5.3
- **fix(dashboard)**: `request_id` now included in `/api/traffic` list response (#173)
- **fix(slm)**: Strip `/v1` suffix from `server_url` preventing double `/v1/v1/chat/completions` path with LM Studio (#174)
- Added `real_e2e_test.sh` with full integration tests

## Verified end-to-end
- OpenClaw → Aegis → OpenAI with real gpt-4o-mini
- Deep SLM via LM Studio Qwen3-30B
- All 5 trust tiers tested in enforce mode
- All 4 screening layers verified (heuristic, classifier, deep SLM, metaprompt)