### PR TITLE
release: v0.5.5 — trace overhaul + dashboard UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/AEGIS-GB/neural-commons"


### PR DESCRIPTION
## What's new in v0.5.5

### CLI Trace Overhaul (#176)
- `aegis trace`: ReqID column, colored SLM verdicts (green/yellow/red), threat score column
- `aegis trace <ID>`: linked receipts section, per-layer pipeline breakdown, request_id display
- `aegis trace --watch`: real-time monitoring mode — refreshes every 2s like `top`, shows mode/uptime/evidence header

### Dashboard UI (#177)
- Traffic table: ReqID column with blue monospace display
- Traffic detail: linked evidence receipts fetched and rendered
- Click any traffic entry to see its full receipt chain

### Verified end-to-end
- OpenClaw → Aegis → OpenAI with real gpt-4o-mini
- All screening layers working: heuristic (<1ms), classifier (18ms), deep SLM (2-3s via LM Studio Qwen3-30B)
- All 5 trust tiers tested in enforce mode