### PR TITLE
Add DLP location tagging and UI improvements

### DIFF
--- a/adapter/aegis-cli/src/trace.rs
+++ b/adapter/aegis-cli/src/trace.rs
@@ -802,7 +802,13 @@ fn show_detail(base: &str, id: u64, show_body: bool, section: Option<&str>, json
                 for f in findings {
                     let cat = f.get("category").and_then(|v| v.as_str()).unwrap_or("?");
                     let desc = f.get("description").and_then(|v| v.as_str()).unwrap_or("");
-                    println!("    {:<10} {}", cat, desc);
+                    let loc_suffix = match f.get("location").and_then(|v| v.as_str()) {
+                        Some("message_content") => "  [message]",
+                        Some("tool_call") => "  [tool call]",
+                        Some("api_protocol") => "  [API metadata]",
+                        _ => "",
+                    };
+                    println!("    {:<10} {}{}", cat, desc, loc_suffix);
                 }
             }
         }

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -1343,15 +1343,25 @@ async function showTraceDetail(id){
         rsh+='<div style="margin-bottom:10px"><span style="font-size:11px;color:#8b949e">REDACTIONS: '+rs.redaction_count+'</span></div>';
       }
       if(rs.findings&&rs.findings.length>0){
-        rsh+='<table class="dtable"><tr><th>Category</th><th>Description</th><th>Original Value</th></tr>';
+        rsh+='<table class="dtable"><tr><th>Category</th><th>Description</th><th>Location</th><th>Original Value</th></tr>';
         for(const f of rs.findings){
           const catCol=f.category==='credential'||f.category==='dangerous_tool'?'#f85149':f.category==='pii'||f.category==='phi'?'#d29922':'#8b949e';
           const vals=(f.matched_values||[]).map(v=>escHtml(v)).join('<br>');
+          const loc=f.location||'unknown';
+          const locColor=loc==='message_content'?'#f85149':loc==='tool_call'?'#d29922':'#484f58';
+          const locLabel=loc==='message_content'?'\u{1F4AC} message':loc==='tool_call'?'\u{1F527} tool call':loc==='api_protocol'?'\u{1F4CB} API metadata':'\u2753 unknown';
           rsh+='<tr><td><span style="color:'+catCol+';font-weight:600">'+escHtml(f.category)+'</span></td>';
           rsh+='<td style="font-size:12px;color:#8b949e">'+escHtml(f.description)+'</td>';
+          rsh+='<td style="font-size:11px;color:'+locColor+'">'+locLabel+'</td>';
           rsh+='<td style="font-size:11px;color:#e1e4e8;font-family:monospace;word-break:break-all">'+vals+'</td></tr>';
         }
         rsh+='</table>';
+        const allProtocol=rs.findings.every(f=>f.location==='api_protocol');
+        if(allProtocol&&rs.findings.length>0){
+          rsh+='<div style="margin-top:8px;padding:8px 12px;background:rgba(139,148,158,0.1);border-radius:4px;font-size:11px;color:#8b949e">';
+          rsh+='All findings are from API protocol metadata (response ID, model name, fingerprint), not from the assistant\'s message content.';
+          rsh+='</div>';
+        }
       }
       h+=dsec('Response Screening — '+(rs.blocked?'BLOCKED':rs.redaction_count+' redaction'+(rs.redaction_count>1?'s':'')),true,rsh);
     }
@@ -1613,7 +1623,9 @@ async function showTrafficDetail(id){
           content='[AEGIS Security Rules injected]\n\n'+content.split('\n\n').slice(-1)[0];
         }
         const cls=m.role==='user'?'chat-user':m.role==='system'?'chat-system':'chat-assistant';
-        h+='<div class="chat-msg '+cls+'"><strong>'+esc(m.role)+'</strong><br>'+esc(content)+'</div>';
+        let roleExtra='';
+        if(m.finish_reason&&m.finish_reason!=='stop'){roleExtra='<span style="color:#d29922;font-size:11px;margin-left:8px">\u26A0 truncated ('+escHtml(m.finish_reason)+')</span>';}
+        h+='<div class="chat-msg '+cls+'"><strong>'+esc(m.role)+'</strong>'+roleExtra+'<br>'+esc(content)+'</div>';
       }
       h+='</div>';
     }

--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -1016,11 +1016,21 @@ fn parse_chat_messages(req_body: &str, resp_body: &str) -> Vec<serde_json::Value
                         .and_then(|r| r.as_str())
                         .unwrap_or("assistant");
                     let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-                    messages.push(serde_json::json!({
+                    let mut msg_json = serde_json::json!({
                         "role": role,
                         "content": content,
                         "source": "response",
-                    }));
+                    });
+                    // Include finish_reason if not "stop" (indicates truncation)
+                    let finish_reason = choice
+                        .get("finish_reason")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("stop");
+                    if finish_reason != "stop" {
+                        msg_json["finish_reason"] =
+                            serde_json::Value::String(finish_reason.to_string());
+                    }
+                    messages.push(msg_json);
                     got_response = true;
                 }
             }

--- a/adapter/aegis-proxy/src/response_screen.rs
+++ b/adapter/aegis-proxy/src/response_screen.rs
@@ -40,6 +40,13 @@ pub struct ResponseFinding {
     /// never sent to the client.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub matched_values: Vec<String>,
+    /// Where in the response this finding was located.
+    /// "message_content" = in the assistant's actual reply
+    /// "api_protocol" = in JSON metadata (id, model, system_fingerprint, etc.)
+    /// "tool_call" = in a tool call argument
+    /// "unknown" = could not determine location
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
 }
 
 impl ResponseScreenResult {
@@ -104,6 +111,7 @@ pub fn screen_response_with_policy(
                 category: p.category.to_string(),
                 description: p.description.to_string(),
                 matched_values: matches,
+                location: None,
             });
             text = new_text;
         }
@@ -207,6 +215,7 @@ pub fn screen_response_with_policy(
                     category: category.to_string(),
                     description,
                     matched_values: vec![entity.text.clone()],
+                    location: None,
                 });
                 // Redact the entity text
                 text = text.replace(
@@ -218,6 +227,13 @@ pub fn screen_response_with_policy(
     }
 
     result.screened = result.redaction_count > 0;
+
+    // Classify the location of each finding post-hoc
+    for finding in &mut result.findings {
+        if finding.location.is_none() {
+            finding.location = Some(classify_finding_location(finding, body));
+        }
+    }
 
     // Apply DLP mode based on trust policy
     match policy.dlp_mode {
@@ -257,6 +273,61 @@ pub fn screen_response_with_policy(
             (text, result)
         }
     }
+}
+
+/// Classify where in the response a finding was located.
+/// Checks matched values against message content, tool call arguments,
+/// and falls back to "api_protocol" for metadata fields.
+fn classify_finding_location(finding: &ResponseFinding, body: &str) -> String {
+    // Try to parse as OpenAI chat completion JSON
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return "unknown".to_string();
+    };
+
+    // Extract message content from all choices
+    let content: String = json
+        .get("choices")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c.get("message"))
+                .filter_map(|m| m.get("content"))
+                .filter_map(|c| c.as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+
+    // Extract tool call arguments
+    let tool_args: Vec<&str> = json
+        .get("choices")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c.get("message"))
+                .filter_map(|m| m.get("tool_calls"))
+                .filter_map(|tc| tc.as_array())
+                .flat_map(|calls| calls.iter())
+                .filter_map(|call| call.get("function"))
+                .filter_map(|f| f.get("arguments"))
+                .filter_map(|a| a.as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Check each matched value against content and tool args
+    for val in &finding.matched_values {
+        if content.contains(val.as_str()) {
+            return "message_content".to_string();
+        }
+        for arg in &tool_args {
+            if arg.contains(val.as_str()) {
+                return "tool_call".to_string();
+            }
+        }
+    }
+
+    "api_protocol".to_string()
 }
 
 /// Check tool calls against trust policy.
@@ -307,6 +378,7 @@ fn check_tools_with_policy(
                 category: "blocked_tool".to_string(),
                 description: reason,
                 matched_values: vec![name.clone()],
+                location: Some("tool_call".to_string()),
             });
         }
     }
@@ -367,6 +439,7 @@ fn check_dangerous_tools(body: &str) -> Option<ResponseFinding> {
                     category: "dangerous_tool".to_string(),
                     description: format!("dangerous tool call: {name}"),
                     matched_values: vec![name.to_string()],
+                    location: Some("tool_call".to_string()),
                 });
             }
         }
@@ -382,6 +455,7 @@ fn check_dangerous_tools(body: &str) -> Option<ResponseFinding> {
                     category: "dangerous_tool".to_string(),
                     description: format!("dangerous tool call: {name}"),
                     matched_values: vec![name.to_string()],
+                    location: Some("tool_call".to_string()),
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Add `location` field to `ResponseFinding` that classifies where each DLP finding was located in the response: `message_content`, `tool_call`, `api_protocol`, or `unknown`
- Dashboard: add Location column to findings table with color-coded labels and emoji indicators; show explanatory note when all findings are from API metadata only; display `finish_reason` truncation warning in chat view
- CLI trace: append location tag (`[message]`, `[tool call]`, `[API metadata]`) to DLP findings output

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all` clean
- [x] `cargo clippy` with CI flags clean
- [ ] Manual: verify dashboard shows Location column for DLP findings
- [ ] Manual: verify CLI `aegis trace` shows location tags on findings
- [ ] Manual: verify finish_reason truncation warning appears for non-stop responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)