### PR TITLE
feat(trustmark): apply temporal decay to vault hygiene

### DIFF
--- a/cluster/trustmark/examples/trustmark_demo.rs
+++ b/cluster/trustmark/examples/trustmark_demo.rs
@@ -40,6 +40,7 @@ fn main() {
         volume_baseline: Some(100),
         relay_forwarded: 100,
         relay_failed: 0,
+        ..Default::default()
     });
     print_score("SCENARIO 2: Perfect (everything healthy)", &perfect);
 
@@ -59,6 +60,7 @@ fn main() {
         volume_baseline: Some(100),
         relay_forwarded: 5,
         relay_failed: 45,
+        ..Default::default()
     });
     print_score("SCENARIO 3: Compromised (tampered, leaking, bursty)", &bad);
 
@@ -78,6 +80,7 @@ fn main() {
         volume_baseline: Some(100),
         relay_forwarded: 0,
         relay_failed: 0,
+        ..Default::default()
     });
     print_score("SCENARIO 4: Typical (2 days, few leaks redacted)", &typical);
 

--- a/cluster/trustmark/src/gather.rs
+++ b/cluster/trustmark/src/gather.rs
@@ -59,6 +59,8 @@ fn gather_from_evidence(store: &aegis_evidence::EvidenceStore, signals: &mut Loc
     let batch_size: u64 = 1000;
     let mut vault_detections: u64 = 0;
     let mut api_call_count: u64 = 0;
+    let mut weighted_vault_leaks: f64 = 0.0;
+    let mut weighted_vault_scans: f64 = 0.0;
     let mut timestamps: Vec<u64> = Vec::new();
     let mut seq: u64 = 1;
 
@@ -77,16 +79,21 @@ fn gather_from_evidence(store: &aegis_evidence::EvidenceStore, signals: &mut Loc
         };
 
         for receipt in &receipts {
-            // Count by type
+            let ts = receipt.core.ts_ms as u64;
+            let age_ms = now_ms.saturating_sub(ts);
+            let weight = crate::decay::decay_factor(age_ms);
+
+            // Count by type (raw and decay-weighted)
             if receipt.core.receipt_type == aegis_schemas::ReceiptType::VaultDetection {
                 vault_detections += 1;
+                weighted_vault_leaks += weight;
             }
             if receipt.core.receipt_type == aegis_schemas::ReceiptType::ApiCall {
                 api_call_count += 1;
+                weighted_vault_scans += weight;
             }
 
             // Timestamps for temporal consistency (all receipts)
-            let ts = receipt.core.ts_ms as u64;
             timestamps.push(ts);
 
             // Count receipts in last 24h
@@ -101,6 +108,8 @@ fn gather_from_evidence(store: &aegis_evidence::EvidenceStore, signals: &mut Loc
     signals.vault_leaks_detected = vault_detections;
     // Vault scans happen per API call, not per receipt (other receipt types don't scan)
     signals.vault_scans_total = api_call_count;
+    signals.weighted_vault_leaks = weighted_vault_leaks;
+    signals.weighted_vault_scans = weighted_vault_scans;
 
     // Sort timestamps for temporal consistency scoring
     timestamps.sort();
@@ -345,6 +354,54 @@ mod tests {
         assert_eq!(s1.manifest_signature_valid, s2.manifest_signature_valid);
         assert_eq!(s1.receipt_timestamps.len(), s2.receipt_timestamps.len());
         assert_eq!(s1.receipts_last_24h, s2.receipts_last_24h);
+    }
+
+    #[test]
+    fn old_leaks_decay_improves_score() {
+        // When all receipts are freshly created, the weighted counts are nearly
+        // equal to raw counts — so the score should be the same as before.
+        // The decay itself is tested in the decay module; here we verify the
+        // gather module actually populates the weighted fields.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("evidence.db");
+
+        let key = aegis_crypto::ed25519::generate_keypair();
+        let recorder = aegis_evidence::EvidenceRecorder::new(&db_path, key).unwrap();
+
+        // 50 normal + 5 vault detections (all recent)
+        for _ in 0..50 {
+            recorder
+                .record_simple(aegis_schemas::ReceiptType::ApiCall, "forward", "200")
+                .unwrap();
+        }
+        for _ in 0..5 {
+            recorder
+                .record_simple(aegis_schemas::ReceiptType::VaultDetection, "vault", "leak")
+                .unwrap();
+        }
+
+        let signals = gather_local_signals(dir.path());
+
+        // Weighted fields should be populated
+        assert!(
+            signals.weighted_vault_scans > 0.0,
+            "weighted scans should be positive"
+        );
+        assert!(
+            signals.weighted_vault_leaks > 0.0,
+            "weighted leaks should be positive"
+        );
+        // For fresh receipts, weighted values are close to raw counts
+        assert!(
+            (signals.weighted_vault_scans - 50.0).abs() < 1.0,
+            "fresh receipts should have weight ~1.0: {}",
+            signals.weighted_vault_scans
+        );
+        assert!(
+            (signals.weighted_vault_leaks - 5.0).abs() < 1.0,
+            "fresh leaks should have weight ~1.0: {}",
+            signals.weighted_vault_leaks
+        );
     }
 
     #[test]

--- a/cluster/trustmark/src/scoring.rs
+++ b/cluster/trustmark/src/scoring.rs
@@ -78,6 +78,12 @@ pub struct LocalSignals {
     pub vault_leaks_detected: u64,
     pub vault_leaks_redacted: u64,
 
+    /// Decay-weighted vault leak count (recent leaks weigh more than old ones).
+    /// When > 0.0, scoring uses this instead of the raw `vault_leaks_detected`.
+    pub weighted_vault_leaks: f64,
+    /// Decay-weighted vault scan count.
+    pub weighted_vault_scans: f64,
+
     // ── Temporal Consistency ──
     /// Receipt timestamps for the scoring window (epoch ms, sorted).
     pub receipt_timestamps: Vec<u64>,
@@ -237,12 +243,19 @@ impl TrustmarkScore {
     }
 
     fn score_vault_hygiene(s: &LocalSignals) -> DimensionScore {
-        let (value, reason) = if s.vault_scans_total == 0 {
+        // Use decay-weighted counts when available, else fall back to raw counts
+        let (leaks, scans) = if s.weighted_vault_scans > 0.0 {
+            (s.weighted_vault_leaks, s.weighted_vault_scans)
+        } else {
+            (s.vault_leaks_detected as f64, s.vault_scans_total as f64)
+        };
+
+        let (value, reason) = if scans == 0.0 {
             (0.5, "no vault scans performed yet".into())
-        } else if s.vault_leaks_detected == 0 {
+        } else if leaks == 0.0 {
             (1.0, format!("{} scans, 0 leaks", s.vault_scans_total))
         } else {
-            let leak_rate = s.vault_leaks_detected as f64 / s.vault_scans_total as f64;
+            let leak_rate = leaks / scans;
             let redaction_rate = if s.vault_leaks_detected > 0 {
                 s.vault_leaks_redacted as f64 / s.vault_leaks_detected as f64
             } else {
@@ -252,7 +265,7 @@ impl TrustmarkScore {
             (
                 value,
                 format!(
-                    "{} leaks in {} scans ({:.1}%), {} redacted",
+                    "{} leaks in {} scans ({:.1}% weighted), {} redacted",
                     s.vault_leaks_detected,
                     s.vault_scans_total,
                     leak_rate * 100.0,
@@ -260,10 +273,10 @@ impl TrustmarkScore {
                 ),
             )
         };
-        let formula = "(1 - leak_rate) × 0.7 + redaction_rate × 0.3".into();
+        let formula = "(1 - decay_weighted_leak_rate) × 0.7 + redaction_rate × 0.3".into();
         let inputs = format!(
-            "{} detections / {} scans · {} redacted",
-            s.vault_leaks_detected, s.vault_scans_total, s.vault_leaks_redacted
+            "{} detections / {} scans · {} redacted · weighted leaks={:.1} scans={:.1}",
+            s.vault_leaks_detected, s.vault_scans_total, s.vault_leaks_redacted, leaks, scans,
         );
         let improve = if value >= 0.95 {
             String::new()
@@ -547,6 +560,8 @@ mod tests {
             vault_scans_total: 500,
             vault_leaks_detected: 0,
             vault_leaks_redacted: 0,
+            weighted_vault_leaks: 0.0,
+            weighted_vault_scans: 0.0,
             receipt_timestamps: (0..288).map(|i| i * 300_000).collect(),
             receipts_last_24h: 288,
             volume_baseline: Some(100),
@@ -573,6 +588,8 @@ mod tests {
             vault_scans_total: 100,
             vault_leaks_detected: 50,
             vault_leaks_redacted: 10,
+            weighted_vault_leaks: 50.0,
+            weighted_vault_scans: 100.0,
             receipt_timestamps: vec![1000, 2000, 100_000_000],
             receipts_last_24h: 3,
             volume_baseline: Some(100),
@@ -742,6 +759,8 @@ mod tests {
             vault_scans_total: 500,
             vault_leaks_detected: 0,
             vault_leaks_redacted: 0,
+            weighted_vault_leaks: 0.0,
+            weighted_vault_scans: 0.0,
             receipt_timestamps: (0..288).map(|i| i * 300_000).collect(),
             receipts_last_24h: 288,
             volume_baseline: Some(100),


### PR DESCRIPTION
## Summary
- Adds `weighted_vault_leaks` and `weighted_vault_scans` fields to `LocalSignals`
- `gather_from_evidence` now computes decay-weighted vault counts using the 90-day half-life
- Scoring uses weighted values when available, falling back to raw counts for backward compat

## Test plan
- [x] `old_leaks_decay_improves_score` verifies weighted fields are populated for fresh receipts
- [x] All existing tests pass (including `full_score_from_real_data` vault score assertions)
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)