### PR TITLE
feat(trustmark): tier gate at startup + warden mode

### DIFF
--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -1172,6 +1172,25 @@ fn print_banner(config: &AdapterConfig, mode: Mode, bot_id: &str, state: &Adapte
     eprintln!("  data dir:   {}", config.data_dir.display());
     eprintln!("  dashboard:  {}", state.dashboard_url());
     eprintln!("  chain seq:  {}", state.chain_head_seq());
+
+    // TRUSTMARK score at startup
+    let tm = state.trustmark_score(&config.data_dir);
+    let score_bp = (tm.score.total * 10000.0).round() as u32;
+    let identity_age = aegis_trustmark::gather::get_identity_age_hours(&config.data_dir);
+    let tier = aegis_trustmark::tiers::resolve_tier(
+        tm.score.total,
+        identity_age,
+        tm.score.total > 0.0,
+        tm.score
+            .dimensions
+            .iter()
+            .any(|d| d.name == "chain_integrity" && d.value >= 0.7),
+        0,
+    );
+    eprintln!(
+        "  trustmark:  {}/{} ({}, {})",
+        score_bp, 10000, tier.current, config.trustmark.mode
+    );
     eprintln!();
 }
 

--- a/adapter/aegis-cli/src/trace.rs
+++ b/adapter/aegis-cli/src/trace.rs
@@ -920,14 +920,23 @@ fn run_watch(
             let mode = s.get("mode").and_then(|v| v.as_str()).unwrap_or("?");
             let uptime = s.get("uptime_secs").and_then(|v| v.as_u64()).unwrap_or(0);
             let receipts = s.get("receipt_count").and_then(|v| v.as_u64()).unwrap_or(0);
+            let trustmark_bp = s
+                .get("trustmark_score_bp")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let uptime_str = if uptime > 3600 {
                 format!("{}h {}m", uptime / 3600, (uptime % 3600) / 60)
             } else {
                 format!("{}m", uptime / 60)
             };
+            let tm_indicator = if trustmark_bp > 0 {
+                format!(" | TRUSTMARK: {}", trustmark_bp)
+            } else {
+                String::new()
+            };
             println!(
-                "  Mode: {} | Uptime: {} | Evidence: {} receipts",
-                mode, uptime_str, receipts
+                "  Mode: {}{} | Uptime: {} | Evidence: {} receipts",
+                mode, tm_indicator, uptime_str, receipts
             );
         }
         println!("  {}", "\u{2500}".repeat(90));

--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -210,6 +210,8 @@ struct DashboardStatus {
     /// Which switchable checks are currently in observe mode (D30).
     /// Empty vec = all checks enforced = no amber banner needed.
     observe_mode_checks: Vec<String>,
+    /// TRUSTMARK score in basis points (0-10000). 0 if not yet computed.
+    trustmark_score_bp: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -361,6 +363,12 @@ async fn dashboard_html() -> axum::response::Html<&'static str> {
 /// GET /dashboard/api/status — current adapter status.
 async fn api_status(State(state): State<Arc<DashboardSharedState>>) -> Json<DashboardStatus> {
     let chain_head = state.evidence.chain_head();
+
+    // Compute TRUSTMARK score from local data
+    let signals = aegis_trustmark::gather::gather_local_signals(&state.data_dir);
+    let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+    let trustmark_score_bp = (score.total * 10000.0).round() as u32;
+
     Json(DashboardStatus {
         mode: (state.mode_fn)().to_string(),
         uptime_secs: state.start_time.elapsed().as_secs(),
@@ -370,6 +378,7 @@ async fn api_status(State(state): State<Arc<DashboardSharedState>>) -> Json<Dash
         health: "healthy".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         observe_mode_checks: (state.observe_mode_checks_fn)(),
+        trustmark_score_bp,
     })
 }
 

--- a/cluster/trustmark/src/scoring.rs
+++ b/cluster/trustmark/src/scoring.rs
@@ -436,6 +436,41 @@ impl TrustmarkScore {
         d.estimated = is_estimated;
         d
     }
+
+    /// Compute TRUSTMARK score in warden mode (self-attested, no mesh relay).
+    ///
+    /// Excludes relay_reliability (always estimated in warden mode) and
+    /// redistributes its weight proportionally across the other 5 dimensions.
+    pub fn compute_warden(signals: &LocalSignals) -> Self {
+        // Zero out relay signals so the relay dimension defaults to 0.5
+        let mut warden_signals = signals.clone();
+        warden_signals.relay_forwarded = 0;
+        warden_signals.relay_failed = 0;
+
+        let mut score = Self::compute(&warden_signals);
+
+        // Redistribute relay weight: remove relay contribution and rescale
+        let relay_idx = score
+            .dimensions
+            .iter()
+            .position(|d| d.name == "relay_reliability");
+        if let Some(idx) = relay_idx {
+            let relay_contribution = score.dimensions[idx].contribution;
+            let remaining_weight: f64 = 1.0 - WEIGHT_RELAY_RELIABILITY;
+
+            // Remove relay from total, then rescale to [0,1]
+            let total_without_relay = score.total - relay_contribution;
+            score.total = (total_without_relay / remaining_weight).clamp(0.0, 1.0);
+
+            // Mark relay as excluded
+            score.dimensions[idx].reason = "excluded (warden mode)".into();
+            score.dimensions[idx].weight = 0.0;
+            score.dimensions[idx].contribution = 0.0;
+            score.dimensions[idx].estimated = true;
+        }
+
+        score
+    }
 }
 
 impl TrustmarkScore {
@@ -802,5 +837,54 @@ mod tests {
         assert!(json.contains("persona_integrity"));
         let rt: TrustmarkScore = serde_json::from_str(&json).unwrap();
         assert!((rt.total - score.total).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn warden_mode_excludes_relay() {
+        let signals = LocalSignals::default();
+        let warden = TrustmarkScore::compute_warden(&signals);
+
+        // Relay dimension should have zero weight
+        let relay = warden
+            .dimensions
+            .iter()
+            .find(|d| d.name == "relay_reliability")
+            .unwrap();
+        assert_eq!(relay.weight, 0.0);
+        assert_eq!(relay.contribution, 0.0);
+        assert!(relay.estimated);
+        assert!(relay.reason.contains("warden"));
+
+        // Total should be rescaled (different from compute)
+        let normal = TrustmarkScore::compute(&signals);
+        // Warden score is the remaining dimensions rescaled to [0,1]
+        assert!(
+            (warden.total - normal.total).abs() > 0.001 || normal.total == 0.0,
+            "warden should differ from normal unless both zero: warden={}, normal={}",
+            warden.total,
+            normal.total
+        );
+    }
+
+    #[test]
+    fn warden_mode_perfect_score() {
+        let signals = LocalSignals {
+            protected_files_total: 9,
+            protected_files_intact: 9,
+            manifest_signature_valid: Some(true),
+            chain_verified: Some(true),
+            chain_receipt_count: 10000,
+            vault_scans_total: 500,
+            receipt_timestamps: (0..288).map(|i| i * 300_000).collect(),
+            receipts_last_24h: 288,
+            volume_baseline: Some(100),
+            ..Default::default()
+        };
+        let warden = TrustmarkScore::compute_warden(&signals);
+        assert!(
+            warden.total > 0.90,
+            "perfect warden should be > 0.90: {}",
+            warden.total
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds TRUSTMARK score to startup banner: `trustmark: 4750/10000 (Tier 1, warden)`
- Adds `trustmark_score_bp` field to dashboard `/api/status` response
- Updates CLI `--watch` header to show TRUSTMARK score when available
- Adds `compute_warden()` scoring function that excludes relay_reliability and rescales

## Test plan
- [x] `warden_mode_excludes_relay` verifies relay dimension is zeroed and marked excluded
- [x] `warden_mode_perfect_score` verifies perfect signals still score > 0.90 in warden mode
- [x] All existing workspace tests pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)