### PR TITLE
feat(trustmark): automatic holster tightening on degradation

### DIFF
--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -883,11 +883,13 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
     }
 
     // 10b. Record initial TRUSTMARK snapshot and start periodic recording (every hour)
+    let trustmark_degraded_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
     {
         let tm_data_dir = data_dir.clone();
         let tm_recorder = recorder.clone();
         let tm_alert_tx = alert_tx.clone();
         let tm_min_score = config.trustmark.min_score;
+        let tm_degraded = trustmark_degraded_flag.clone();
         tokio::spawn(async move {
             // Initial snapshot at startup
             let signals = aegis_trustmark::gather::gather_local_signals(&tm_data_dir);
@@ -901,6 +903,10 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                 );
             }
             check_trustmark_health_alerts(&score, tm_min_score, &tm_alert_tx);
+            tm_degraded.store(
+                score.total < tm_min_score,
+                std::sync::atomic::Ordering::Relaxed,
+            );
 
             // Hourly snapshots
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
@@ -918,6 +924,10 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
                     );
                 }
                 check_trustmark_health_alerts(&score, tm_min_score, &tm_alert_tx);
+                tm_degraded.store(
+                    score.total < tm_min_score,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
             }
         });
         info!("TRUSTMARK scoring started (snapshot every 1h)");
@@ -1056,13 +1066,14 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
         }
     };
 
-    aegis_proxy::proxy::start_with_traffic_full(
+    aegis_proxy::proxy::start_with_traffic_full_ex(
         proxy_config,
         hooks,
         Some((dashboard_path, dashboard_router)),
         Some(traffic_recorder),
         Some(traffic_slm_updater),
         trust_config,
+        trustmark_degraded_flag,
     )
     .await
     .map_err(|e| StartupError::Proxy(format!("{e}")))?;

--- a/adapter/aegis-proxy/src/proxy.rs
+++ b/adapter/aegis-proxy/src/proxy.rs
@@ -125,6 +125,10 @@ pub struct AppState {
     pub trust_config: Arc<std::sync::RwLock<crate::channel_trust::TrustConfig>>,
     /// Semaphore limiting concurrent SLM screenings (prevents GPU exhaustion via DDoS).
     pub slm_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Whether the TRUSTMARK score is degraded (below min_score).
+    /// Updated by the adapter's TRUSTMARK snapshot task.
+    /// When true, Permissive holster is downgraded to Balanced.
+    pub trustmark_degraded: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Build the axum router for the proxy server.
@@ -203,6 +207,28 @@ pub async fn start_with_traffic_full(
     traffic_slm_updater: Option<Arc<TrafficSlmUpdater>>,
     trust_config: crate::channel_trust::TrustConfig,
 ) -> Result<(), ProxyError> {
+    start_with_traffic_full_ex(
+        config,
+        hooks,
+        dashboard,
+        traffic_recorder,
+        traffic_slm_updater,
+        trust_config,
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .await
+}
+
+/// Start the proxy server with full traffic recording and TRUSTMARK degradation flag.
+pub async fn start_with_traffic_full_ex(
+    config: ProxyConfig,
+    hooks: MiddlewareHooks,
+    dashboard: Option<(String, Router)>,
+    traffic_recorder: Option<Arc<TrafficRecorder>>,
+    traffic_slm_updater: Option<Arc<TrafficSlmUpdater>>,
+    trust_config: crate::channel_trust::TrustConfig,
+    trustmark_degraded: Arc<std::sync::atomic::AtomicBool>,
+) -> Result<(), ProxyError> {
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(300)) // 5 min for long LLM responses
         .build()
@@ -227,6 +253,7 @@ pub async fn start_with_traffic_full(
         traffic_slm_updater,
         trust_config: Arc::new(std::sync::RwLock::new(trust_config)),
         slm_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        trustmark_degraded,
     };
 
     let app = build_router(state, dashboard);
@@ -665,7 +692,9 @@ async fn forward_request(
         body_text,
         channel_trust,
         request_id: pipeline.request_id_str(),
-        trustmark_degraded: false,
+        trustmark_degraded: state
+            .trustmark_degraded
+            .load(std::sync::atomic::Ordering::Relaxed),
     };
 
     // Recording is handled by recording_middleware — no manual recording needed.
@@ -1660,6 +1689,7 @@ mod tests {
                 crate::channel_trust::TrustConfig::default(),
             )),
             slm_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            trustmark_degraded: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let _router = build_router(state, None);
         // If it doesn't panic, it works
@@ -1679,7 +1709,38 @@ mod tests {
                 crate::channel_trust::TrustConfig::default(),
             )),
             slm_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            trustmark_degraded: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert_eq!(state.identity_fingerprint.as_deref(), Some("abc123def456"));
+    }
+
+    #[test]
+    fn trustmark_degraded_flag_wired() {
+        let degraded = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let state = AppState {
+            config: ProxyConfig::default(),
+            client: Client::new(),
+            hooks: Arc::new(MiddlewareHooks::default()),
+            identity_fingerprint: None,
+            rate_limiter: None,
+            traffic_recorder: None,
+            traffic_slm_updater: None,
+            trust_config: Arc::new(std::sync::RwLock::new(
+                crate::channel_trust::TrustConfig::default(),
+            )),
+            slm_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            trustmark_degraded: degraded.clone(),
+        };
+        assert!(
+            state
+                .trustmark_degraded
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+        degraded.store(false, std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            !state
+                .trustmark_degraded
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `trustmark_degraded: Arc<AtomicBool>` to proxy `AppState`
- TRUSTMARK snapshot task updates the flag when total score < min_score
- Proxy handler reads the flag into `RequestInfo.trustmark_degraded`
- New `start_with_traffic_full_ex` function passes the shared flag from adapter to proxy

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] New `trustmark_degraded_flag_wired` test verifies shared atomic flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)