### PR TITLE
feat(trustmark): warden/mesh mode switch

### DIFF
--- a/adapter/aegis-adapter/src/server.rs
+++ b/adapter/aegis-adapter/src/server.rs
@@ -246,6 +246,7 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
         dashboard_path: config.dashboard.path.clone(),
         alert_tx: alert_tx.clone(),
         trustmark_cache: std::sync::RwLock::new(None),
+        trustmark_mode: config.trustmark.mode.clone(),
     });
 
     // 5b. Create traffic store (in-memory ring buffer for dashboard inspector)
@@ -278,6 +279,7 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
         start_time,
         data_dir: data_dir.clone(),
         auth_token: generate_dashboard_token(&config),
+        trustmark_mode: config.trustmark.mode.clone(),
     });
     let dashboard_router = aegis_dashboard::routes::routes(dashboard_state);
     let dashboard_path = config.dashboard.path.clone();
@@ -889,16 +891,26 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
         let tm_recorder = recorder.clone();
         let tm_alert_tx = alert_tx.clone();
         let tm_min_score = config.trustmark.min_score;
+        let tm_mode = config.trustmark.mode.clone();
         let tm_degraded = trustmark_degraded_flag.clone();
         tokio::spawn(async move {
+            let compute_score = |signals: &aegis_trustmark::scoring::LocalSignals| {
+                if tm_mode == "warden" {
+                    aegis_trustmark::scoring::TrustmarkScore::compute_warden(signals)
+                } else {
+                    aegis_trustmark::scoring::TrustmarkScore::compute(signals)
+                }
+            };
+
             // Initial snapshot at startup
             let signals = aegis_trustmark::gather::gather_local_signals(&tm_data_dir);
-            let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+            let score = compute_score(&signals);
             if let Err(e) = aegis_trustmark::persist::record_snapshot(&tm_recorder, &score) {
                 tracing::warn!("failed to record initial TRUSTMARK snapshot: {e}");
             } else {
                 tracing::info!(
                     score = format!("{:.3}", score.total),
+                    mode = %tm_mode,
                     "TRUSTMARK snapshot recorded"
                 );
             }
@@ -914,12 +926,13 @@ pub async fn start(config: AdapterConfig, mode_override: Option<Mode>) -> Result
             loop {
                 interval.tick().await;
                 let signals = aegis_trustmark::gather::gather_local_signals(&tm_data_dir);
-                let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+                let score = compute_score(&signals);
                 if let Err(e) = aegis_trustmark::persist::record_snapshot(&tm_recorder, &score) {
                     tracing::warn!("failed to record TRUSTMARK snapshot: {e}");
                 } else {
                     tracing::info!(
                         score = format!("{:.3}", score.total),
+                        mode = %tm_mode,
                         "TRUSTMARK hourly snapshot"
                     );
                 }

--- a/adapter/aegis-adapter/src/state.rs
+++ b/adapter/aegis-adapter/src/state.rs
@@ -159,6 +159,9 @@ pub struct AdapterState {
     /// Cached TRUSTMARK score with freshness tracking.
     /// Auto-recomputed when stale (>5 minutes).
     pub trustmark_cache: std::sync::RwLock<Option<TrustmarkCache>>,
+
+    /// TRUSTMARK scoring mode ("warden" or "mesh").
+    pub trustmark_mode: String,
 }
 
 impl AdapterState {
@@ -257,7 +260,11 @@ impl AdapterState {
 
         // Recompute
         let signals = aegis_trustmark::gather::gather_local_signals(data_dir);
-        let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+        let score = if self.trustmark_mode == "warden" {
+            aegis_trustmark::scoring::TrustmarkScore::compute_warden(&signals)
+        } else {
+            aegis_trustmark::scoring::TrustmarkScore::compute(&signals)
+        };
         let cache_entry = TrustmarkCache {
             score,
             computed_at_ms: now_ms,
@@ -295,6 +302,7 @@ mod tests {
             dashboard_path: "/dashboard".into(),
             alert_tx,
             trustmark_cache: std::sync::RwLock::new(None),
+            trustmark_mode: "warden".to_string(),
         }
     }
 

--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -74,6 +74,8 @@ pub struct DashboardSharedState {
     /// Dashboard auth token. If set, all dashboard/API requests require
     /// `Authorization: Bearer <token>` or `?token=<token>` query param.
     pub auth_token: Option<String>,
+    /// TRUSTMARK scoring mode ("warden" or "mesh").
+    pub trustmark_mode: String,
 }
 
 // ── Router ───────────────────────────────────────────────────────────────────
@@ -366,7 +368,11 @@ async fn api_status(State(state): State<Arc<DashboardSharedState>>) -> Json<Dash
 
     // Compute TRUSTMARK score from local data
     let signals = aegis_trustmark::gather::gather_local_signals(&state.data_dir);
-    let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+    let score = if state.trustmark_mode == "warden" {
+        aegis_trustmark::scoring::TrustmarkScore::compute_warden(&signals)
+    } else {
+        aegis_trustmark::scoring::TrustmarkScore::compute(&signals)
+    };
     let trustmark_score_bp = (score.total * 10000.0).round() as u32;
 
     Json(DashboardStatus {
@@ -1166,7 +1172,11 @@ fn parse_sse_response_text(sse_body: &str) -> Option<String> {
 /// Uses the same gather function as the CLI — single source of truth.
 async fn api_trustmark(State(state): State<Arc<DashboardSharedState>>) -> Json<serde_json::Value> {
     let signals = aegis_trustmark::gather::gather_local_signals(&state.data_dir);
-    let score = aegis_trustmark::scoring::TrustmarkScore::compute(&signals);
+    let score = if state.trustmark_mode == "warden" {
+        aegis_trustmark::scoring::TrustmarkScore::compute_warden(&signals)
+    } else {
+        aegis_trustmark::scoring::TrustmarkScore::compute(&signals)
+    };
     let identity_age = aegis_trustmark::gather::get_identity_age_hours(&state.data_dir);
     let tier = aegis_trustmark::tiers::resolve_tier(
         score.total,
@@ -1182,6 +1192,7 @@ async fn api_trustmark(State(state): State<Arc<DashboardSharedState>>) -> Json<s
         "computed_at_ms": score.computed_at_ms,
         "tier": tier,
         "identity_age_hours": identity_age,
+        "mode": state.trustmark_mode,
     }))
 }
 


### PR DESCRIPTION
## Summary
- Use `compute_warden()` when `config.trustmark.mode == "warden"` (default) throughout all TRUSTMARK scoring paths
- Add `trustmark_mode` field to `AdapterState` and `DashboardSharedState`
- Include mode in the `/dashboard/api/trustmark` response
- Consistent warden mode across snapshot task, state cache, and dashboard APIs

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)