### PR TITLE
feat(gateway): add GET /trustmark/:bot_id with evidence-based scoring

### DIFF
--- a/cluster/gateway/src/main.rs
+++ b/cluster/gateway/src/main.rs
@@ -6,7 +6,10 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use axum::{Extension, Router, middleware, routing::get, routing::post};
+use axum::{
+    Extension, Router, middleware,
+    routing::{get, post},
+};
 use clap::Parser;
 use serde::Deserialize;
 use tokio::signal;
@@ -123,6 +126,10 @@ async fn main() {
         .route(
             "/evidence/batch",
             post(routes::post_evidence_batch::<MemoryStore>),
+        )
+        .route(
+            "/trustmark/{bot_id}",
+            get(routes::get_trustmark::<MemoryStore>),
         )
         .layer(Extension(evidence_store))
         .layer(middleware::from_fn(auth::auth_middleware));

--- a/cluster/gateway/src/routes.rs
+++ b/cluster/gateway/src/routes.rs
@@ -12,6 +12,7 @@
 //! All routes require NC-Ed25519 authentication.
 //! Rate limits per D24. Credit deductions per D19.
 
+use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
@@ -207,6 +208,130 @@ pub async fn post_evidence_batch<S: EvidenceStore>(
     }
 }
 
+/// Compute a basic TRUSTMARK score from cluster-stored evidence.
+///
+/// This is a simplified cluster-side scoring that works from receipt metadata
+/// only (no adapter-side signals like persona integrity or vault hygiene).
+/// Dimensions backed by adapter-only data are set to conservative defaults.
+fn compute_trustmark_from_evidence(records: &[EvidenceRecord]) -> aegis_schemas::TrustmarkScore {
+    let bp = |v: f64| aegis_schemas::BasisPoints::clamped((v * 10_000.0).round() as u32);
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    // Chain integrity: check sequence is monotonic with no gaps
+    let chain_integrity = if records.is_empty() {
+        0.3 // no evidence yet
+    } else {
+        let mut sorted = records.to_vec();
+        sorted.sort_by_key(|r| r.seq);
+        let has_gaps = sorted.windows(2).any(|w| w[1].seq != w[0].seq + 1);
+        if has_gaps {
+            0.5 // gaps in sequence
+        } else {
+            1.0 // monotonic, no gaps
+        }
+    };
+
+    // Contribution volume: receipts in last 24h vs baseline of 100
+    let baseline = 100.0_f64;
+    let day_ago = now_ms - 86_400_000;
+    let recent_count = records.iter().filter(|r| r.ts_ms > day_ago).count() as f64;
+    let contribution_volume = (recent_count / baseline).min(1.0);
+
+    // Temporal consistency: coefficient of variation of inter-receipt intervals
+    let temporal_consistency = if records.len() < 3 {
+        0.5
+    } else {
+        let mut timestamps: Vec<i64> = records.iter().map(|r| r.ts_ms).collect();
+        timestamps.sort();
+        let intervals: Vec<f64> = timestamps
+            .windows(2)
+            .map(|w| (w[1] - w[0]) as f64)
+            .collect();
+        let mean = intervals.iter().sum::<f64>() / intervals.len() as f64;
+        if mean == 0.0 {
+            0.5
+        } else {
+            let variance =
+                intervals.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / intervals.len() as f64;
+            let cv = variance.sqrt() / mean;
+            (1.0 - (cv - 0.5).max(0.0) / 1.5).clamp(0.2, 1.0)
+        }
+    };
+
+    // Dimensions only observable from adapter side -- conservative defaults
+    let persona_integrity = 0.5; // unknown from cluster
+    let vault_hygiene = 0.5; // unknown from cluster
+    let relay_reliability = 0.5; // mesh not active
+
+    // Weighted sum (same weights as D13)
+    let total = persona_integrity * 0.25
+        + chain_integrity * 0.20
+        + vault_hygiene * 0.15
+        + temporal_consistency * 0.15
+        + relay_reliability * 0.15
+        + contribution_volume * 0.10;
+
+    let tier = if total >= 0.40 {
+        aegis_schemas::trustmark::Tier::Tier3
+    } else if total >= 0.20 {
+        aegis_schemas::trustmark::Tier::Tier2
+    } else {
+        aegis_schemas::trustmark::Tier::Tier1
+    };
+
+    aegis_schemas::TrustmarkScore {
+        score_bp: bp(total),
+        dimensions: aegis_schemas::trustmark::TrustmarkDimensions {
+            relay_reliability: bp(relay_reliability),
+            persona_integrity: bp(persona_integrity),
+            chain_integrity: bp(chain_integrity),
+            contribution_volume: bp(contribution_volume),
+            temporal_consistency: bp(temporal_consistency),
+            vault_hygiene: bp(vault_hygiene),
+        },
+        tier,
+        computed_at_ms: now_ms,
+    }
+}
+
+/// GET /trustmark/:bot_id -- query TRUSTMARK score for a bot.
+///
+/// Returns the computed TRUSTMARK score based on stored evidence.
+/// Returns 404 if no evidence exists for the given bot_id.
+pub async fn get_trustmark<S: EvidenceStore>(
+    Extension(store): Extension<S>,
+    Path(bot_id): Path<String>,
+) -> impl IntoResponse {
+    // Query stored evidence for this bot
+    let records = match store.get_for_bot(&bot_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response();
+        }
+    };
+
+    if records.is_empty() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("no evidence found for bot {bot_id}")
+            })),
+        )
+            .into_response();
+    }
+
+    let score = compute_trustmark_from_evidence(&records);
+    (StatusCode::OK, Json(score)).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,7 +339,7 @@ mod tests {
     use crate::store::MemoryStore;
     use axum::body::Body;
     use axum::http::Request;
-    use axum::routing::post;
+    use axum::routing::{get, post};
     use axum::{Router, middleware};
     use ed25519_dalek::Signer;
     use tower::ServiceExt;
@@ -249,6 +374,7 @@ mod tests {
         let authed = Router::new()
             .route("/evidence", post(post_evidence::<MemoryStore>))
             .route("/evidence/batch", post(post_evidence_batch::<MemoryStore>))
+            .route("/trustmark/{bot_id}", get(get_trustmark::<MemoryStore>))
             .layer(Extension(store))
             .layer(middleware::from_fn(auth::auth_middleware));
 
@@ -489,5 +615,109 @@ mod tests {
 
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ── Trustmark query tests ──
+
+    #[tokio::test]
+    async fn get_trustmark_unknown_bot_returns_404() {
+        let store = MemoryStore::new();
+        let app = test_app(store);
+        let sk = aegis_crypto::ed25519::generate_keypair();
+        let (pubkey, sig, ts_ms) = sign_request(&sk, "GET", "/trustmark/unknown_bot", b"");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/trustmark/unknown_bot")
+            .header("authorization", format!("NC-Ed25519 {pubkey}:{sig}"))
+            .header("x-aegis-timestamp", ts_ms.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_trustmark_known_bot_returns_score() {
+        let store = MemoryStore::new();
+        let bot_id = "bot_abc123";
+
+        // Pre-populate store with some evidence
+        for i in 0..10 {
+            let record = EvidenceRecord {
+                id: format!("receipt-{i}"),
+                bot_fingerprint: bot_id.to_string(),
+                seq: i + 1,
+                receipt_type: "api_call".to_string(),
+                ts_ms: 1700000000000 + i * 60_000, // 1 minute apart
+                core_json: "{}".to_string(),
+                receipt_hash: format!("{:064x}", i),
+                request_id: None,
+            };
+            store.insert(record).await.unwrap();
+        }
+
+        let app = test_app(store);
+        let sk = aegis_crypto::ed25519::generate_keypair();
+        let path = format!("/trustmark/{bot_id}");
+        let (pubkey, sig, ts_ms) = sign_request(&sk, "GET", &path, b"");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", format!("NC-Ed25519 {pubkey}:{sig}"))
+            .header("x-aegis-timestamp", ts_ms.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Score should be present and reasonable
+        assert!(json["score_bp"].is_number());
+        let score_bp = json["score_bp"].as_u64().unwrap();
+        assert!(score_bp > 0, "score should be positive: {score_bp}");
+        assert!(score_bp <= 10000, "score should be <= 10000: {score_bp}");
+
+        // Dimensions should be present
+        assert!(json["dimensions"]["chain_integrity"].is_number());
+        assert!(json["dimensions"]["persona_integrity"].is_number());
+        assert!(json["dimensions"]["vault_hygiene"].is_number());
+        assert!(json["dimensions"]["relay_reliability"].is_number());
+        assert!(json["dimensions"]["contribution_volume"].is_number());
+        assert!(json["dimensions"]["temporal_consistency"].is_number());
+
+        // Tier should be present
+        assert!(json["tier"].is_string());
+    }
+
+    #[test]
+    fn compute_trustmark_empty_records() {
+        // Should not panic on empty
+        let score = compute_trustmark_from_evidence(&[]);
+        assert!(score.score_bp.value() > 0);
+    }
+
+    #[test]
+    fn compute_trustmark_perfect_chain() {
+        let records: Vec<EvidenceRecord> = (0..100)
+            .map(|i| EvidenceRecord {
+                id: format!("r-{i}"),
+                bot_fingerprint: "bot1".to_string(),
+                seq: i + 1,
+                receipt_type: "api_call".to_string(),
+                ts_ms: 1700000000000 + i * 300_000, // 5 min apart
+                core_json: "{}".to_string(),
+                receipt_hash: format!("{:064x}", i),
+                request_id: None,
+            })
+            .collect();
+        let score = compute_trustmark_from_evidence(&records);
+        // Chain integrity should be 10000 (no gaps)
+        assert_eq!(score.dimensions.chain_integrity.value(), 10000);
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /trustmark/:bot_id` endpoint returning TRUSTMARK score computed from stored evidence
- Score dimensions from cluster-observable data: chain integrity, contribution volume, temporal consistency
- Adapter-only dimensions (persona integrity, vault hygiene, relay reliability) default to 0.5
- Returns `aegis_schemas::TrustmarkScore` (score_bp, dimensions, tier)
- Returns 404 if no evidence exists for the bot

## Test plan
- [x] Query unknown bot returns 404
- [x] Query bot with pre-populated evidence returns score JSON with all dimensions
- [x] Empty evidence produces reasonable score (conservative defaults)
- [x] Perfect chain (no gaps) produces chain_integrity = 10000
- [x] `cargo test --workspace` passes (28 gateway tests)
- [x] `cargo clippy` and `cargo fmt` clean

Generated with Claude Code