### PR TITLE
feat(gateway): TRUSTMARK cache with NATS subscriber

### DIFF
--- a/cluster/gateway/src/main.rs
+++ b/cluster/gateway/src/main.rs
@@ -17,7 +17,7 @@ use tokio::signal;
 use tracing::info;
 
 use aegis_gateway::auth;
-use aegis_gateway::nats_bridge::NatsBridge;
+use aegis_gateway::nats_bridge::{NatsBridge, TrustmarkCache};
 use aegis_gateway::routes;
 use aegis_gateway::store::MemoryStore;
 
@@ -127,6 +127,9 @@ async fn main() {
     // Evidence store (in-memory for now; swap with PostgresStore in production)
     let evidence_store = MemoryStore::new();
 
+    // TRUSTMARK cache (populated by NATS subscription, used by GET /trustmark)
+    let trustmark_cache = Arc::new(TrustmarkCache::new());
+
     // Optional NATS bridge
     let nats_bridge: Option<Arc<NatsBridge>> = match &config.nats_url {
         Some(url) => match NatsBridge::connect(url).await {
@@ -138,6 +141,11 @@ async fn main() {
                 let store_for_sub = evidence_store.clone();
                 if let Err(e) = bridge.subscribe_evidence(Arc::new(store_for_sub)).await {
                     tracing::warn!("failed to subscribe to evidence.new: {e}");
+                }
+
+                // Start trustmark cache subscriber (updates local cache on score changes)
+                if let Err(e) = bridge.subscribe_trustmark(trustmark_cache.clone()).await {
+                    tracing::warn!("failed to subscribe to trustmark.updated: {e}");
                 }
 
                 Some(bridge)
@@ -165,6 +173,7 @@ async fn main() {
             get(routes::get_trustmark::<MemoryStore>),
         )
         .layer(Extension(evidence_store))
+        .layer(Extension(trustmark_cache))
         .layer(Extension(nats_bridge))
         .layer(middleware::from_fn(auth::auth_middleware));
 

--- a/cluster/gateway/src/nats_bridge.rs
+++ b/cluster/gateway/src/nats_bridge.rs
@@ -9,10 +9,12 @@
 //!   NATS trustmark.updated → WSS push to bot
 //!   NATS broadcast.* → WSS push to all connected bots
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_nats::Client;
 use futures::StreamExt;
+use tokio::sync::RwLock;
 
 use crate::routes::compute_trustmark_from_evidence;
 use crate::store::EvidenceStore;
@@ -157,6 +159,45 @@ impl NatsBridge {
 
         Ok(())
     }
+
+    /// Subscribe to `trustmark.updated` and update the local cache.
+    ///
+    /// This implements the `gateway-cache` consumer pattern from the NATS topology:
+    /// push delivery, ack-none. Each incoming message updates the in-memory
+    /// cache so `GET /trustmark/:bot_id` can serve cached scores.
+    pub async fn subscribe_trustmark(
+        &self,
+        cache: Arc<TrustmarkCache>,
+    ) -> Result<(), async_nats::SubscribeError> {
+        let mut subscriber = self.client.subscribe("trustmark.updated").await?;
+
+        tokio::spawn(async move {
+            tracing::info!("trustmark cache subscriber started on trustmark.updated");
+            while let Some(msg) = subscriber.next().await {
+                match serde_json::from_slice::<TrustmarkUpdate>(&msg.payload) {
+                    Ok(update) => {
+                        let cached = CachedScore {
+                            score_bp: update.score.score_bp.value(),
+                            dimensions: serde_json::to_value(&update.score.dimensions)
+                                .unwrap_or_default(),
+                            tier: serde_json::to_value(update.score.tier)
+                                .map(|v| v.as_str().unwrap_or("tier1").to_string())
+                                .unwrap_or_else(|_| "tier1".to_string()),
+                            computed_at_ms: update.score.computed_at_ms,
+                        };
+                        tracing::debug!(bot_id = %update.bot_id, score_bp = cached.score_bp, "cache updated");
+                        cache.insert(update.bot_id, cached).await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to parse trustmark.updated message");
+                    }
+                }
+            }
+            tracing::warn!("trustmark cache subscriber ended unexpectedly");
+        });
+
+        Ok(())
+    }
 }
 
 /// TRUSTMARK update message published to `trustmark.updated`.
@@ -168,6 +209,56 @@ pub struct TrustmarkUpdate {
     pub bot_id: String,
     /// Recomputed TRUSTMARK score
     pub score: aegis_schemas::TrustmarkScore,
+}
+
+/// Cached TRUSTMARK score entry.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CachedScore {
+    /// Overall score in basis points
+    pub score_bp: u32,
+    /// Per-dimension breakdown (serialized for flexibility)
+    pub dimensions: serde_json::Value,
+    /// Tier string
+    pub tier: String,
+    /// Unix epoch milliseconds when this score was computed
+    pub computed_at_ms: i64,
+}
+
+/// In-memory cache of TRUSTMARK scores, updated via NATS subscription.
+///
+/// The cache is populated by `subscribe_trustmark` which listens for
+/// `trustmark.updated` messages. The `GET /trustmark/:bot_id` handler
+/// checks this cache first before falling back to evidence-based computation.
+#[derive(Debug, Clone, Default)]
+pub struct TrustmarkCache {
+    scores: Arc<RwLock<HashMap<String, CachedScore>>>,
+}
+
+impl TrustmarkCache {
+    /// Create a new empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or update a cached score for a bot.
+    pub async fn insert(&self, bot_id: String, score: CachedScore) {
+        self.scores.write().await.insert(bot_id, score);
+    }
+
+    /// Look up a cached score for a bot.
+    pub async fn get(&self, bot_id: &str) -> Option<CachedScore> {
+        self.scores.read().await.get(bot_id).cloned()
+    }
+
+    /// Return the number of cached entries.
+    pub async fn len(&self) -> usize {
+        self.scores.read().await.len()
+    }
+
+    /// Check if the cache is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.scores.read().await.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/cluster/gateway/src/routes.rs
+++ b/cluster/gateway/src/routes.rs
@@ -20,7 +20,7 @@ use axum::response::IntoResponse;
 use axum::{Extension, Json};
 
 use crate::auth::VerifiedIdentity;
-use crate::nats_bridge::NatsBridge;
+use crate::nats_bridge::{NatsBridge, TrustmarkCache};
 use crate::store::{EvidenceRecord, EvidenceStore};
 
 /// Maximum receipts per batch
@@ -315,13 +315,30 @@ pub fn compute_trustmark_from_evidence(
 
 /// GET /trustmark/:bot_id -- query TRUSTMARK score for a bot.
 ///
-/// Returns the computed TRUSTMARK score based on stored evidence.
+/// Checks the NATS-fed cache first for a precomputed score.
+/// Falls back to evidence-based computation if not cached.
 /// Returns 404 if no evidence exists for the given bot_id.
 pub async fn get_trustmark<S: EvidenceStore>(
     Extension(store): Extension<S>,
+    Extension(cache): Extension<Arc<TrustmarkCache>>,
     Path(bot_id): Path<String>,
 ) -> impl IntoResponse {
-    // Query stored evidence for this bot
+    // Check cache first
+    if let Some(cached) = cache.get(&bot_id).await {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "score_bp": cached.score_bp,
+                "dimensions": cached.dimensions,
+                "tier": cached.tier,
+                "computed_at_ms": cached.computed_at_ms,
+                "cached": true,
+            })),
+        )
+            .into_response();
+    }
+
+    // Cache miss — compute from evidence store
     let records = match store.get_for_bot(&bot_id).await {
         Ok(r) => r,
         Err(e) => {
@@ -351,7 +368,7 @@ pub async fn get_trustmark<S: EvidenceStore>(
 mod tests {
     use super::*;
     use crate::auth;
-    use crate::nats_bridge::NatsBridge;
+    use crate::nats_bridge::{CachedScore, NatsBridge, TrustmarkCache};
     use crate::store::MemoryStore;
     use axum::body::Body;
     use axum::http::Request;
@@ -387,12 +404,17 @@ mod tests {
     }
 
     fn test_app(store: MemoryStore) -> Router {
+        test_app_with_cache(store, TrustmarkCache::new())
+    }
+
+    fn test_app_with_cache(store: MemoryStore, cache: TrustmarkCache) -> Router {
         let nats_bridge: Option<Arc<NatsBridge>> = None;
         let authed = Router::new()
             .route("/evidence", post(post_evidence::<MemoryStore>))
             .route("/evidence/batch", post(post_evidence_batch::<MemoryStore>))
             .route("/trustmark/{bot_id}", get(get_trustmark::<MemoryStore>))
             .layer(Extension(store))
+            .layer(Extension(Arc::new(cache)))
             .layer(Extension(nats_bridge))
             .layer(middleware::from_fn(auth::auth_middleware));
 
@@ -764,5 +786,174 @@ mod tests {
         let score = compute_trustmark_from_evidence(&records);
         // Chain integrity should be 10000 (no gaps)
         assert_eq!(score.dimensions.chain_integrity.value(), 10000);
+    }
+
+    // ── Cache tests ──
+
+    #[tokio::test]
+    async fn cache_insert_and_lookup() {
+        let cache = TrustmarkCache::new();
+        assert!(cache.is_empty().await);
+
+        let score = CachedScore {
+            score_bp: 7500,
+            dimensions: serde_json::json!({
+                "chain_integrity": 10000,
+                "persona_integrity": 5000,
+            }),
+            tier: "tier3".to_string(),
+            computed_at_ms: 1700000000000,
+        };
+
+        cache.insert("bot_abc".to_string(), score.clone()).await;
+        assert_eq!(cache.len().await, 1);
+
+        let fetched = cache.get("bot_abc").await.unwrap();
+        assert_eq!(fetched.score_bp, 7500);
+        assert_eq!(fetched.tier, "tier3");
+        assert_eq!(fetched.computed_at_ms, 1700000000000);
+    }
+
+    #[tokio::test]
+    async fn cache_miss_returns_none() {
+        let cache = TrustmarkCache::new();
+        assert!(cache.get("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_update_overwrites() {
+        let cache = TrustmarkCache::new();
+
+        let score1 = CachedScore {
+            score_bp: 5000,
+            dimensions: serde_json::json!({}),
+            tier: "tier2".to_string(),
+            computed_at_ms: 1700000000000,
+        };
+        cache.insert("bot1".to_string(), score1).await;
+
+        let score2 = CachedScore {
+            score_bp: 8000,
+            dimensions: serde_json::json!({}),
+            tier: "tier3".to_string(),
+            computed_at_ms: 1700000001000,
+        };
+        cache.insert("bot1".to_string(), score2).await;
+
+        assert_eq!(cache.len().await, 1);
+        let fetched = cache.get("bot1").await.unwrap();
+        assert_eq!(fetched.score_bp, 8000);
+        assert_eq!(fetched.tier, "tier3");
+    }
+
+    #[tokio::test]
+    async fn get_trustmark_returns_cached_score() {
+        let store = MemoryStore::new();
+        let cache = TrustmarkCache::new();
+
+        // Pre-populate cache (simulating NATS subscription update)
+        let cached = CachedScore {
+            score_bp: 8500,
+            dimensions: serde_json::json!({
+                "chain_integrity": 10000,
+                "persona_integrity": 5000,
+                "vault_hygiene": 5000,
+                "temporal_consistency": 9000,
+                "relay_reliability": 5000,
+                "contribution_volume": 7000,
+            }),
+            tier: "tier3".to_string(),
+            computed_at_ms: 1700000000000,
+        };
+        cache.insert("cached_bot".to_string(), cached).await;
+
+        let app = test_app_with_cache(store, cache);
+        let sk = aegis_crypto::ed25519::generate_keypair();
+        let (pubkey, sig, ts_ms) = sign_request(&sk, "GET", "/trustmark/cached_bot", b"");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/trustmark/cached_bot")
+            .header("authorization", format!("NC-Ed25519 {pubkey}:{sig}"))
+            .header("x-aegis-timestamp", ts_ms.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Should be the cached score
+        assert_eq!(json["score_bp"], 8500);
+        assert_eq!(json["cached"], true);
+        assert_eq!(json["tier"], "tier3");
+    }
+
+    #[tokio::test]
+    async fn get_trustmark_falls_back_to_evidence_when_not_cached() {
+        let store = MemoryStore::new();
+        let cache = TrustmarkCache::new();
+        let bot_id = "uncached_bot";
+
+        // Add evidence but no cache entry
+        for i in 0..5 {
+            let record = EvidenceRecord {
+                id: format!("receipt-{i}"),
+                bot_fingerprint: bot_id.to_string(),
+                seq: i + 1,
+                receipt_type: "api_call".to_string(),
+                ts_ms: 1700000000000 + i * 60_000,
+                core_json: "{}".to_string(),
+                receipt_hash: format!("{:064x}", i),
+                request_id: None,
+            };
+            store.insert(record).await.unwrap();
+        }
+
+        let app = test_app_with_cache(store, cache);
+        let sk = aegis_crypto::ed25519::generate_keypair();
+        let path = format!("/trustmark/{bot_id}");
+        let (pubkey, sig, ts_ms) = sign_request(&sk, "GET", &path, b"");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", format!("NC-Ed25519 {pubkey}:{sig}"))
+            .header("x-aegis-timestamp", ts_ms.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Should be computed (not cached), score should be present
+        assert!(json["score_bp"].is_number());
+        assert!(json.get("cached").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_trustmark_uncached_no_evidence_returns_404() {
+        let store = MemoryStore::new();
+        let cache = TrustmarkCache::new();
+
+        let app = test_app_with_cache(store, cache);
+        let sk = aegis_crypto::ed25519::generate_keypair();
+        let (pubkey, sig, ts_ms) = sign_request(&sk, "GET", "/trustmark/nobody", b"");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/trustmark/nobody")
+            .header("authorization", format!("NC-Ed25519 {pubkey}:{sig}"))
+            .header("x-aegis-timestamp", ts_ms.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Summary
- Add `TrustmarkCache` struct with `RwLock<HashMap>` for in-memory TRUSTMARK score caching
- Add `CachedScore` type with score_bp, dimensions, tier, computed_at_ms fields
- Add `subscribe_trustmark()` to NatsBridge: listens on `trustmark.updated`, updates cache
- Update `GET /trustmark/:bot_id` to check cache first (returns `"cached": true`), fall back to evidence computation
- Wire cache and subscriber into Gateway startup
- 43 tests passing (6 new: cache insert/lookup, miss, overwrite, cached GET, uncached fallback GET, uncached 404)

## Test plan
- [x] All original gateway tests still pass (28 from Phase 1 + PR 6-7 additions)
- [x] New test: cache insert and lookup returns correct values
- [x] New test: cache miss returns None
- [x] New test: cache update overwrites previous entry
- [x] New test: GET /trustmark returns cached score with `cached: true`
- [x] New test: GET /trustmark falls back to evidence computation when not cached
- [x] New test: GET /trustmark returns 404 when neither cached nor has evidence
- [x] `cargo test --workspace` all green
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)