### PR TITLE
feat: mesh drill-down, Botawiki tab, relay log, full cluster visibility

### DIFF
--- a/adapter/aegis-cli/src/botawiki_cmd.rs
+++ b/adapter/aegis-cli/src/botawiki_cmd.rs
@@ -1,0 +1,343 @@
+//! `aegis botawiki` — Botawiki knowledge base CLI commands.
+//!
+//! Fetches data from the Gateway's Botawiki API endpoints and renders
+//! rich terminal output with aligned tables.
+
+use serde::Deserialize;
+
+use crate::mesh_cmd::{format_age_ms, format_bot_id_short};
+
+// ── API response types ──────────────────────────────────────────────
+
+#[derive(Deserialize, Debug)]
+pub struct AllClaimsResponse {
+    pub claims: Vec<ClaimView>,
+    #[allow(dead_code)]
+    pub count: usize,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClaimView {
+    pub id: String,
+    pub claim_type: serde_json::Value,
+    pub namespace: String,
+    pub attester_id: String,
+    pub confidence_bp: u32,
+    pub status: String,
+    pub votes: Vec<VoteView>,
+    pub validators: Vec<String>,
+    pub submitted_at_ms: i64,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct VoteView {
+    pub validator_id: String,
+    pub approve: bool,
+    pub ts_ms: i64,
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+fn print_connection_error(gateway_url: &str) {
+    eprintln!("Error: cannot connect to Gateway at {gateway_url}");
+    eprintln!("  Is the Gateway running? Start with: aegis-gateway -c gateway_config.toml");
+}
+
+fn format_claim_type(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        _ => v.to_string(),
+    }
+}
+
+fn format_timestamp(ms: i64) -> String {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    let age = now_ms - ms;
+    if age < 0 {
+        "just now".to_string()
+    } else {
+        format_age_ms(age)
+    }
+}
+
+// ── Subcommand runners ──────────────────────────────────────────────
+
+pub fn run_list(gateway_url: &str) {
+    let url = format!("{gateway_url}/botawiki/claims/all");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    let data: AllClaimsResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse claims response: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Botawiki Claims \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}"
+    );
+    println!();
+
+    if data.claims.is_empty() {
+        println!("  No claims found.");
+        println!();
+        return;
+    }
+
+    println!(
+        "  {:<18} {:<28} {:<8} {:<12} {:<12} {}",
+        "ID", "Namespace", "Type", "Status", "Confidence", "Votes"
+    );
+    println!(
+        "  {:<18} {:<28} {:<8} {:<12} {:<12} {}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+    );
+
+    let mut canonical_count = 0u32;
+    let mut quarantine_count = 0u32;
+    let mut tombstoned_count = 0u32;
+
+    for claim in &data.claims {
+        match claim.status.as_str() {
+            "canonical" => canonical_count += 1,
+            "quarantine" => quarantine_count += 1,
+            "tombstoned" => tombstoned_count += 1,
+            _ => {}
+        }
+
+        let id_short = format_bot_id_short(&claim.id);
+        let claim_type = format_claim_type(&claim.claim_type);
+        let approvals = claim.votes.iter().filter(|v| v.approve).count();
+        let total_votes = claim.votes.len();
+
+        println!(
+            "  {:<18} {:<28} {:<8} {:<12} {:<12} {}/{}",
+            id_short,
+            &claim.namespace,
+            claim_type,
+            claim.status,
+            format!("{} bp", claim.confidence_bp),
+            approvals,
+            total_votes,
+        );
+    }
+
+    println!();
+    println!(
+        "  {} claims total ({} canonical, {} quarantine, {} tombstoned)",
+        data.claims.len(),
+        canonical_count,
+        quarantine_count,
+        tombstoned_count,
+    );
+    println!();
+}
+
+pub fn run_show(gateway_url: &str, claim_id: &str) {
+    let url = format!("{gateway_url}/botawiki/claims/all");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    let data: AllClaimsResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse claims response: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let claim = data
+        .claims
+        .iter()
+        .find(|c| c.id == claim_id || c.id.starts_with(claim_id));
+
+    let claim = match claim {
+        Some(c) => c,
+        None => {
+            eprintln!("Error: claim not found: {claim_id}");
+            std::process::exit(1);
+        }
+    };
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Claim {}... \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}",
+        format_bot_id_short(&claim.id)
+    );
+    println!();
+    println!("  ID:           {}", claim.id);
+    println!("  Type:         {}", format_claim_type(&claim.claim_type));
+    println!("  Namespace:    {}", claim.namespace);
+    println!(
+        "  Attester:     {}",
+        format_bot_id_short(&claim.attester_id)
+    );
+    println!("  Confidence:   {} bp", claim.confidence_bp);
+    println!("  Status:       {}", claim.status);
+    println!(
+        "  Submitted:    {}",
+        format_timestamp(claim.submitted_at_ms)
+    );
+    println!();
+
+    println!("  \u{2500}\u{2500} Payload \u{2500}\u{2500}");
+    let payload_str = serde_json::to_string_pretty(&claim.payload).unwrap_or_default();
+    for line in payload_str.lines() {
+        println!("  {line}");
+    }
+    println!();
+
+    if !claim.votes.is_empty() {
+        println!("  \u{2500}\u{2500} Votes \u{2500}\u{2500}");
+        for (i, vote) in claim.votes.iter().enumerate() {
+            let action = if vote.approve { "approve" } else { "reject " };
+            println!(
+                "  v{}: {} ({})",
+                i + 1,
+                action,
+                format_timestamp(vote.ts_ms)
+            );
+        }
+        println!();
+    }
+}
+
+pub fn run_search(gateway_url: &str, namespace: &str) {
+    let url = format!("{gateway_url}/botawiki/claims/all");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    let data: AllClaimsResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse claims response: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let matched: Vec<&ClaimView> = data
+        .claims
+        .iter()
+        .filter(|c| c.namespace.contains(namespace))
+        .collect();
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Search: \"{}\" \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}",
+        namespace
+    );
+    println!();
+
+    if matched.is_empty() {
+        println!("  No claims matching namespace \"{namespace}\"");
+        println!();
+        return;
+    }
+
+    println!(
+        "  {:<18} {:<28} {:<8} {:<12} {}",
+        "ID", "Namespace", "Type", "Status", "Confidence"
+    );
+    println!(
+        "  {:<18} {:<28} {:<8} {:<12} {}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+    );
+
+    for claim in &matched {
+        let id_short = format_bot_id_short(&claim.id);
+        let claim_type = format_claim_type(&claim.claim_type);
+        println!(
+            "  {:<18} {:<28} {:<8} {:<12} {} bp",
+            id_short, &claim.namespace, claim_type, claim.status, claim.confidence_bp,
+        );
+    }
+
+    println!();
+    println!("  {} claims found", matched.len());
+    println!();
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_all_claims_response() {
+        let json = r#"{
+            "claims": [
+                {
+                    "id": "abc12345-6789-abcd-ef01-234567890abc",
+                    "claim_type": "skills",
+                    "namespace": "b/skills/malicious-urls",
+                    "attester_id": "a7f3b2c1d9e4f5a2",
+                    "confidence_bp": 8500,
+                    "status": "canonical",
+                    "votes": [
+                        {"validator_id": "v1", "approve": true, "ts_ms": 1700000000000},
+                        {"validator_id": "v2", "approve": true, "ts_ms": 1700000001000}
+                    ],
+                    "validators": ["v1", "v2", "v3"],
+                    "submitted_at_ms": 1700000000000,
+                    "payload": {"description": "test"}
+                }
+            ],
+            "count": 1
+        }"#;
+        let resp: AllClaimsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.count, 1);
+        assert_eq!(resp.claims.len(), 1);
+        assert_eq!(resp.claims[0].namespace, "b/skills/malicious-urls");
+        assert_eq!(resp.claims[0].confidence_bp, 8500);
+        assert_eq!(resp.claims[0].votes.len(), 2);
+        assert!(resp.claims[0].votes[0].approve);
+    }
+
+    #[test]
+    fn format_claim_type_string_and_other() {
+        let s = serde_json::Value::String("skills".into());
+        assert_eq!(format_claim_type(&s), "skills");
+
+        let o = serde_json::json!({"type": "lore"});
+        assert_eq!(format_claim_type(&o), r#"{"type":"lore"}"#);
+    }
+}

--- a/adapter/aegis-cli/src/main.rs
+++ b/adapter/aegis-cli/src/main.rs
@@ -39,6 +39,7 @@ use clap::{Parser, Subcommand};
 use aegis_adapter::config::{AdapterConfig, AdapterMode};
 
 mod backup;
+mod botawiki_cmd;
 mod mesh_cmd;
 mod trace;
 mod trustmark_cmd;
@@ -255,8 +256,34 @@ enum Commands {
         gateway_url: String,
     },
 
+    /// Botawiki knowledge base operations
+    Botawiki {
+        #[command(subcommand)]
+        action: BotawikiCommands,
+
+        /// Gateway URL
+        #[arg(long, default_value = "http://127.0.0.1:8080")]
+        gateway_url: String,
+    },
+
     /// Show version information
     Version,
+}
+
+#[derive(Subcommand)]
+enum BotawikiCommands {
+    /// List all claims
+    List,
+    /// Show a specific claim by ID
+    Show {
+        /// Claim ID (full UUID or prefix)
+        claim_id: String,
+    },
+    /// Search claims by namespace
+    Search {
+        /// Namespace pattern to search for
+        namespace: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -378,12 +405,28 @@ enum MeshCommands {
     Status,
     /// List connected peer bots with TRUSTMARK scores
     Peers,
+    /// Show detail for a specific peer bot
+    Peer {
+        /// Bot ID (full hex or prefix)
+        bot_id: String,
+    },
     /// Show relay message statistics
     Relay,
+    /// Show recent relay message log
+    RelayLog {
+        /// Max events to show
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+    },
     /// Show Botawiki claim summary
     Claims,
     /// Show dead-drop queue status
     DeadDrops,
+    /// Show dead-drop detail for a bot
+    DeadDrop {
+        /// Recipient bot ID
+        bot_id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1147,9 +1190,25 @@ fn main() {
         }) => match action {
             MeshCommands::Status => mesh_cmd::run_status(&gateway_url),
             MeshCommands::Peers => mesh_cmd::run_peers(&gateway_url),
+            MeshCommands::Peer { bot_id } => mesh_cmd::run_peer_detail(&gateway_url, &bot_id),
             MeshCommands::Relay => mesh_cmd::run_relay(&gateway_url),
+            MeshCommands::RelayLog { limit } => mesh_cmd::run_relay_log(&gateway_url, limit),
             MeshCommands::Claims => mesh_cmd::run_claims(&gateway_url),
             MeshCommands::DeadDrops => mesh_cmd::run_dead_drops(&gateway_url),
+            MeshCommands::DeadDrop { bot_id } => {
+                mesh_cmd::run_dead_drop_detail(&gateway_url, &bot_id)
+            }
+        },
+
+        Some(Commands::Botawiki {
+            action,
+            gateway_url,
+        }) => match action {
+            BotawikiCommands::List => botawiki_cmd::run_list(&gateway_url),
+            BotawikiCommands::Show { claim_id } => botawiki_cmd::run_show(&gateway_url, &claim_id),
+            BotawikiCommands::Search { namespace } => {
+                botawiki_cmd::run_search(&gateway_url, &namespace)
+            }
         },
 
         Some(Commands::Version) => {

--- a/adapter/aegis-cli/src/mesh_cmd.rs
+++ b/adapter/aegis-cli/src/mesh_cmd.rs
@@ -358,6 +358,245 @@ pub fn run_dead_drops(gateway_url: &str) {
     println!();
 }
 
+// ── Drill-down response types ──────────────────────────────────────
+
+#[derive(Deserialize, Debug)]
+pub struct PeerDetailResponse {
+    pub bot_id: String,
+    pub online: bool,
+    pub score_bp: u32,
+    pub dimensions: serde_json::Value,
+    pub tier: String,
+    pub computed_at_ms: i64,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RelayLogResponse {
+    pub events: Vec<RelayLogEvent>,
+    #[allow(dead_code)]
+    pub count: usize,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RelayLogEvent {
+    pub from: String,
+    pub to: String,
+    pub status: String,
+    pub msg_type: String,
+    pub ts_ms: i64,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DeadDropDetailResponse {
+    pub bot_id: String,
+    pub drops: Vec<DeadDropMessage>,
+    #[allow(dead_code)]
+    pub count: usize,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DeadDropMessage {
+    pub from: String,
+    pub body: String,
+    pub msg_type: String,
+    pub ts_ms: i64,
+    pub expires_ms: i64,
+}
+
+// ── Drill-down subcommand runners ──────────────────────────────────
+
+pub fn run_peer_detail(gateway_url: &str, bot_id: &str) {
+    let url = format!("{gateway_url}/mesh/peers/{bot_id}");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    if resp.status().as_u16() == 404 {
+        eprintln!("Error: bot not found: {bot_id}");
+        std::process::exit(1);
+    }
+
+    let data: PeerDetailResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse peer detail: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Peer Detail \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}"
+    );
+    println!();
+    println!("  Bot ID:       {}", data.bot_id);
+    println!(
+        "  Status:       {}",
+        if data.online { "online" } else { "offline" }
+    );
+    println!("  TRUSTMARK:    {} bp", data.score_bp);
+    println!("  Tier:         {}", data.tier);
+    println!(
+        "  Computed at:  {}",
+        format_age_ms(now_ms() - data.computed_at_ms)
+    );
+    println!();
+
+    // Render dimensions if available
+    if let Some(dims) = data.dimensions.as_array() {
+        println!("  \u{2500}\u{2500} Dimensions \u{2500}\u{2500}");
+        for dim in dims {
+            let name = dim["name"].as_str().unwrap_or("?");
+            let score = dim["score"].as_f64().unwrap_or(0.0);
+            let target = dim["target"].as_f64().unwrap_or(1.0);
+            let bar_width = 20;
+            let filled = ((score / target.max(0.001)) * bar_width as f64)
+                .round()
+                .min(bar_width as f64) as usize;
+            let empty = bar_width - filled;
+            println!(
+                "  {:<22} {:.3} / {:.3}  {}{}",
+                name,
+                score,
+                target,
+                "\u{2588}".repeat(filled),
+                "\u{2591}".repeat(empty)
+            );
+        }
+    } else if data.dimensions.is_object() {
+        println!("  \u{2500}\u{2500} Dimensions \u{2500}\u{2500}");
+        let pretty = serde_json::to_string_pretty(&data.dimensions).unwrap_or_default();
+        for line in pretty.lines() {
+            println!("  {line}");
+        }
+    }
+    println!();
+}
+
+pub fn run_relay_log(gateway_url: &str, limit: usize) {
+    let url = format!("{gateway_url}/mesh/relay/log?limit={limit}");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    let data: RelayLogResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse relay log: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Relay Log \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}"
+    );
+    println!();
+
+    if data.events.is_empty() {
+        println!("  No relay events recorded yet.");
+        println!();
+        return;
+    }
+
+    println!(
+        "  {:<14} {:<14} {:<14} {:<14} {}",
+        "Time", "From", "To", "Status", "Type"
+    );
+    println!(
+        "  {:<14} {:<14} {:<14} {:<14} {}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+    );
+
+    for event in &data.events {
+        let age = format_age_ms(now_ms() - event.ts_ms);
+        println!(
+            "  {:<14} {:<14} {:<14} {:<14} {}",
+            age,
+            format_bot_id_short(&event.from),
+            format_bot_id_short(&event.to),
+            &event.status,
+            &event.msg_type,
+        );
+    }
+
+    println!();
+    println!("  {} events shown", data.events.len());
+    println!();
+}
+
+pub fn run_dead_drop_detail(gateway_url: &str, bot_id: &str) {
+    let url = format!("{gateway_url}/mesh/dead-drops/{bot_id}");
+    let resp = match client().get(&url).send() {
+        Ok(r) => r,
+        Err(_) => {
+            print_connection_error(gateway_url);
+            std::process::exit(1);
+        }
+    };
+
+    let data: DeadDropDetailResponse = match resp.json() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to parse dead-drop detail: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!();
+    println!(
+        "\u{2501}\u{2501}\u{2501} Dead-Drops for {} \u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}",
+        format_bot_id_short(bot_id)
+    );
+    println!();
+
+    if data.drops.is_empty() {
+        println!("  No pending dead-drops for this bot.");
+        println!();
+        return;
+    }
+
+    for (i, drop) in data.drops.iter().enumerate() {
+        let age = format_age_ms(now_ms() - drop.ts_ms);
+        let ttl = format_age_ms(drop.expires_ms - now_ms());
+        let body_preview = if drop.body.len() > 80 {
+            format!("{}...", &drop.body[..80])
+        } else {
+            drop.body.clone()
+        };
+
+        println!("  [{}/{}]", i + 1, data.drops.len());
+        println!("    From:    {}", format_bot_id_short(&drop.from));
+        println!("    Type:    {}", drop.msg_type);
+        println!("    Age:     {}", age);
+        println!("    Expires: {}", ttl);
+        println!("    Body:    {}", body_preview);
+        println!();
+    }
+
+    println!("  {} pending messages", data.drops.len());
+    println!();
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -446,6 +685,51 @@ mod tests {
         assert_eq!(format_age_ms(30_000), "0m ago");
         // negative
         assert_eq!(format_age_ms(-1000), "just now");
+    }
+
+    #[test]
+    fn parse_peer_detail_response() {
+        let json = r#"{
+            "bot_id": "a7f3b2c1d9e4f5a2",
+            "online": true,
+            "score_bp": 8420,
+            "dimensions": [{"name": "chain_integrity", "score": 0.95, "target": 1.0}],
+            "tier": "T2",
+            "computed_at_ms": 1700000000000
+        }"#;
+        let resp: PeerDetailResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.bot_id, "a7f3b2c1d9e4f5a2");
+        assert!(resp.online);
+        assert_eq!(resp.score_bp, 8420);
+        assert_eq!(resp.tier, "T2");
+    }
+
+    #[test]
+    fn parse_relay_log_response() {
+        let json = r#"{
+            "events": [
+                {"from": "bot_a", "to": "bot_b", "status": "delivered", "msg_type": "relay", "ts_ms": 1700000000000}
+            ],
+            "count": 1
+        }"#;
+        let resp: RelayLogResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.count, 1);
+        assert_eq!(resp.events[0].status, "delivered");
+    }
+
+    #[test]
+    fn parse_dead_drop_detail_response() {
+        let json = r#"{
+            "bot_id": "bot_b",
+            "drops": [
+                {"from": "bot_a", "body": "hello", "msg_type": "relay", "ts_ms": 1700000000000, "expires_ms": 1700259200000}
+            ],
+            "count": 1
+        }"#;
+        let resp: DeadDropDetailResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.bot_id, "bot_b");
+        assert_eq!(resp.drops.len(), 1);
+        assert_eq!(resp.drops[0].body, "hello");
     }
 
     #[test]

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -3,7 +3,7 @@
 //! The full HTML/CSS/JS dashboard is embedded in the binary as a static string.
 //! Total size target: <50KB.
 //!
-//! 10 tabs:
+//! 12 tabs:
 //!   1. Trace — primary real-time request trace view
 //!   2. Overview — "nothing changed, here's what we see" + TRUSTMARK
 //!   3. Evidence Explorer — receipt chain viewer
@@ -14,7 +14,8 @@
 //!   8. Trust — channel trust + context observability
 //!   9. Traffic Inspector — request/response inspector with SLM column
 //!  10. Emergency Alerts — broadcast messages
-//!  11. Mesh — Gateway mesh peer visualization + relay stats
+//!  11. Mesh — Gateway mesh peer visualization + relay stats + drill-down
+//!  12. Botawiki — knowledge base claims viewer
 //!
 //! Refresh: 2s polling via fetch() to /dashboard/api/* endpoints (D12).
 
@@ -154,6 +155,7 @@ table.dtable .screening-row:hover{background:#1c2128}
 <div class="tab" data-tab="traffic">Traffic</div>
 <div class="tab" data-tab="alerts">Alerts</div>
 <div class="tab" data-tab="mesh">Mesh</div>
+<div class="tab" data-tab="botawiki">Botawiki</div>
 </div>
 <div class="content">
 <!-- ═══ TRACE PANEL (primary view) ═══ -->
@@ -245,14 +247,32 @@ table.dtable .screening-row:hover{background:#1c2128}
 <div class="card" id="mesh-peers-card"><h2>Mesh Peers</h2>
 <div id="mesh-peers-table"></div>
 </div>
+<div class="card" id="mesh-peer-detail-card" style="display:none;margin-top:16px"><h2>Peer Detail</h2>
+<div id="mesh-peer-detail"></div>
+</div>
 <div class="card" id="mesh-relay-card" style="margin-top:16px"><h2>Relay Stats</h2>
 <div id="mesh-relay"></div>
+</div>
+<div class="card" id="mesh-relay-log-card" style="margin-top:16px"><h2>Relay Log</h2>
+<div id="mesh-relay-log"></div>
 </div>
 <div class="card" id="mesh-claims-card" style="margin-top:16px"><h2>Claims Summary</h2>
 <div id="mesh-claims"></div>
 </div>
 <div class="card" id="mesh-deaddrops-card" style="margin-top:16px"><h2>Dead-Drop Queue</h2>
 <div id="mesh-deaddrops"></div>
+</div>
+<div class="card" id="mesh-deaddrop-detail-card" style="display:none;margin-top:16px"><h2>Dead-Drop Messages</h2>
+<div id="mesh-deaddrop-detail"></div>
+</div>
+</div>
+<div class="panel" id="panel-botawiki" style="display:none">
+<div class="grid" id="botawiki-stats"></div>
+<div class="card" id="botawiki-claims-card"><h2>Claims</h2>
+<div id="botawiki-claims-table"></div>
+</div>
+<div class="card" id="botawiki-detail-card" style="display:none;margin-top:16px"><h2>Claim Detail</h2>
+<div id="botawiki-detail"></div>
 </div>
 </div>
 </div>
@@ -1696,18 +1716,19 @@ async function pollMesh(){
   const relayDiv=document.getElementById('mesh-relay');
   const claimsDiv=document.getElementById('mesh-claims');
   const deaddropsDiv=document.getElementById('mesh-deaddrops');
+  const relayLogDiv=document.getElementById('mesh-relay-log');
   if(!meshGatewayUrl){
     stats.innerHTML='<div class="card"><div class="stat status-warn">Not Configured</div><div class="stat-label">Mesh Gateway</div></div>';
     peersTable.innerHTML='<p class="empty-state">No gateway_url configured. Set <code>gateway_url</code> in config to enable mesh.</p>';
-    relayDiv.innerHTML='';claimsDiv.innerHTML='';deaddropsDiv.innerHTML='';
+    relayDiv.innerHTML='';claimsDiv.innerHTML='';deaddropsDiv.innerHTML='';relayLogDiv.innerHTML='';
     return;
   }
-  // Fetch mesh endpoints from Gateway
-  let status=null,peers=null,claims=null,deadDrops=null;
+  let status=null,peers=null,claims=null,deadDrops=null,relayLog=null;
   try{status=await(await fetch(meshGatewayUrl+'/mesh/status')).json();}catch(e){}
   try{peers=await(await fetch(meshGatewayUrl+'/mesh/peers')).json();}catch(e){}
   try{claims=await(await fetch(meshGatewayUrl+'/mesh/claims')).json();}catch(e){}
   try{deadDrops=await(await fetch(meshGatewayUrl+'/mesh/dead-drops')).json();}catch(e){}
+  try{relayLog=await(await fetch(meshGatewayUrl+'/mesh/relay/log?limit=10')).json();}catch(e){}
   // Stats bar
   let sc='';
   if(status){
@@ -1720,15 +1741,18 @@ async function pollMesh(){
     sc+='<div class="card"><div class="stat status-warn">Unreachable</div><div class="stat-label">Gateway at '+esc(meshGatewayUrl)+'</div></div>';
   }
   stats.innerHTML=sc;
-  // Peers table
+  // Peers table (clickable rows)
   if(peers&&Array.isArray(peers.peers)&&peers.peers.length>0){
-    let h='<table class="dtable"><tr><th>Bot ID</th><th>TRUSTMARK</th><th>Tier</th><th>Status</th></tr>';
+    let h='<table class="dtable"><tr><th>Bot ID</th><th>TRUSTMARK</th><th>Tier</th><th>Status</th><th></th></tr>';
     for(const p of peers.peers){
       const id=(p.bot_id||'').substring(0,16)+'...';
       const sc=p.score_bp!=null?p.score_bp+' bp':'—';
       const tier=p.tier||'—';
       const st=p.online?'<span class="status-ok">online</span>':'<span class="status-warn">offline</span>';
-      h+='<tr><td style="font-family:monospace;font-size:11px">'+esc(id)+'</td><td>'+sc+'</td><td>'+esc(tier)+'</td><td>'+st+'</td></tr>';
+      h+='<tr class="screening-row" style="cursor:pointer" onclick="showPeerDetail(\''+esc(p.bot_id)+'\')">';
+      h+='<td style="font-family:monospace;font-size:11px">'+esc(id)+'</td><td>'+sc+'</td><td>'+esc(tier)+'</td><td>'+st+'</td>';
+      h+='<td style="font-size:11px;color:#58a6ff">detail →</td>';
+      h+='</tr>';
     }
     h+='</table>';peersTable.innerHTML=h;
   }else{
@@ -1754,6 +1778,23 @@ async function pollMesh(){
     }
     relayDiv.innerHTML=rh;
   }else{relayDiv.innerHTML='<p class="empty-state">No relay data.</p>';}
+  // Relay log
+  if(relayLog&&relayLog.events&&relayLog.events.length>0){
+    let rl='<table class="dtable"><tr><th>Time</th><th>From</th><th>To</th><th>Status</th><th>Type</th></tr>';
+    for(const e of relayLog.events){
+      const statusColors={delivered:'#3fb950',quarantined:'#f85149',dead_dropped:'#d29922'};
+      const color=statusColors[e.status]||'#8b949e';
+      const fromId=(e.from||'').substring(0,12)+'...';
+      const toId=(e.to||'').substring(0,12)+'...';
+      rl+='<tr><td style="white-space:nowrap;font-size:12px">'+fmtTimeShort(e.ts_ms)+'</td>';
+      rl+='<td style="font-family:monospace;font-size:11px">'+esc(fromId)+'</td>';
+      rl+='<td style="font-family:monospace;font-size:11px">'+esc(toId)+'</td>';
+      rl+='<td style="color:'+color+';font-weight:600">'+e.status+'</td>';
+      rl+='<td>'+esc(e.msg_type)+'</td></tr>';
+    }
+    rl+='</table>';
+    relayLogDiv.innerHTML=rl;
+  }else{relayLogDiv.innerHTML='<p class="empty-state">No relay events recorded yet.</p>';}
   // Claims
   if(claims&&(claims.total||0)>0){
     let ch='<div style="display:flex;gap:24px;flex-wrap:wrap;font-size:13px;margin-bottom:12px">';
@@ -1773,25 +1814,174 @@ async function pollMesh(){
     }
     claimsDiv.innerHTML=ch;
   }else{claimsDiv.innerHTML='<p class="empty-state">No Botawiki claims.</p>';}
-  // Dead-drops
+  // Dead-drops (clickable rows)
   if(deadDrops&&(deadDrops.total||0)>0){
     let dh='<div style="font-size:13px;margin-bottom:12px">Total queued: <strong>'+deadDrops.total+'</strong> for <strong>'+deadDrops.recipients_count+'</strong> recipients</div>';
     if(deadDrops.recipients&&deadDrops.recipients.length>0){
-      dh+='<table class="dtable"><tr><th>Recipient</th><th>Queued</th><th>Oldest</th></tr>';
+      dh+='<table class="dtable"><tr><th>Recipient</th><th>Queued</th><th>Oldest</th><th></th></tr>';
       for(const r of deadDrops.recipients){
         const id=(r.bot_id||'').substring(0,16)+'...';
         const age=r.oldest_age_ms!=null?Math.round(r.oldest_age_ms/60000)+'m ago':'—';
-        dh+='<tr><td style="font-family:monospace;font-size:11px">'+esc(id)+'</td><td>'+r.count+'</td><td>'+age+'</td></tr>';
+        dh+='<tr class="screening-row" style="cursor:pointer" onclick="showDeadDropDetail(\''+esc(r.bot_id)+'\')">';
+        dh+='<td style="font-family:monospace;font-size:11px">'+esc(id)+'</td><td>'+r.count+'</td><td>'+age+'</td>';
+        dh+='<td style="font-size:11px;color:#58a6ff">detail →</td></tr>';
       }
       dh+='</table>';
     }
     deaddropsDiv.innerHTML=dh;
   }else{deaddropsDiv.innerHTML='<p class="empty-state">No dead-drops in queue.</p>';}
 }
+async function showPeerDetail(botId){
+  if(!meshGatewayUrl)return;
+  const card=document.getElementById('mesh-peer-detail-card');
+  const detail=document.getElementById('mesh-peer-detail');
+  try{
+    const d=await(await fetch(meshGatewayUrl+'/mesh/peers/'+encodeURIComponent(botId))).json();
+    if(d.error){detail.innerHTML='<p class="empty-state">'+esc(d.error)+'</p>';card.style.display='block';return;}
+    let h='<span class="detail-back" onclick="document.getElementById(\'mesh-peer-detail-card\').style.display=\'none\'">← Close</span>';
+    h+='<div style="margin-top:12px;display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px">';
+    h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">BOT ID</div><div style="font-family:monospace;font-size:11px;margin-top:4px;word-break:break-all">'+esc(d.bot_id)+'</div></div>';
+    h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">STATUS</div><div style="font-size:16px;margin-top:4px">'+(d.online?'<span class="status-ok">online</span>':'<span class="status-warn">offline</span>')+'</div></div>';
+    h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">TRUSTMARK</div><div style="font-size:20px;font-weight:600;margin-top:4px">'+d.score_bp+' bp</div></div>';
+    h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">TIER</div><div style="font-size:16px;font-weight:600;margin-top:4px">'+esc(d.tier)+'</div></div>';
+    h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">COMPUTED</div><div style="font-size:12px;margin-top:4px">'+fmtTime(d.computed_at_ms)+'</div></div>';
+    h+='</div>';
+    if(Array.isArray(d.dimensions)&&d.dimensions.length>0){
+      h+='<div style="margin-top:16px;font-size:12px;color:#8b949e;margin-bottom:8px">DIMENSIONS</div>';
+      for(const dim of d.dimensions){
+        const name=dim.name||'?';const score=dim.score||0;const target=dim.target||1;
+        const pct=Math.min(100,Math.round(score/Math.max(target,0.001)*100));
+        const color=pct>=80?'#3fb950':pct>=50?'#d29922':'#f85149';
+        h+='<div class="dim-bar"><span class="dim-bar-label">'+esc(name)+'</span>';
+        h+='<span class="dim-bar-track"><span class="dim-bar-fill" style="width:'+pct+'%;background:'+color+'"></span></span>';
+        h+='<span class="dim-bar-val">'+score.toFixed(3)+'</span></div>';
+      }
+    }
+    detail.innerHTML=h;
+    card.style.display='block';
+  }catch(e){detail.innerHTML='<p class="empty-state">Failed to load peer detail.</p>';card.style.display='block';}
+}
+async function showDeadDropDetail(botId){
+  if(!meshGatewayUrl)return;
+  const card=document.getElementById('mesh-deaddrop-detail-card');
+  const detail=document.getElementById('mesh-deaddrop-detail');
+  try{
+    const d=await(await fetch(meshGatewayUrl+'/mesh/dead-drops/'+encodeURIComponent(botId))).json();
+    let h='<span class="detail-back" onclick="document.getElementById(\'mesh-deaddrop-detail-card\').style.display=\'none\'">← Close</span>';
+    h+='<div style="margin-top:8px;font-size:13px;margin-bottom:12px">Recipient: <strong style="font-family:monospace">'+esc(botId)+'</strong> — '+d.count+' messages</div>';
+    if(d.drops&&d.drops.length>0){
+      h+='<table class="dtable"><tr><th>#</th><th>From</th><th>Type</th><th>Age</th><th>Body Preview</th></tr>';
+      const now=Date.now();
+      for(let i=0;i<d.drops.length;i++){
+        const dd=d.drops[i];
+        const age=Math.round((now-dd.ts_ms)/60000)+'m ago';
+        const body=(dd.body||'').substring(0,60);
+        h+='<tr><td>'+(i+1)+'</td>';
+        h+='<td style="font-family:monospace;font-size:11px">'+esc((dd.from||'').substring(0,12)+'...')+'</td>';
+        h+='<td>'+esc(dd.msg_type)+'</td>';
+        h+='<td>'+age+'</td>';
+        h+='<td style="font-size:12px;color:#8b949e;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+esc(body)+'</td></tr>';
+      }
+      h+='</table>';
+    }else{h+='<p class="empty-state">No pending messages.</p>';}
+    detail.innerHTML=h;
+    card.style.display='block';
+  }catch(e){detail.innerHTML='<p class="empty-state">Failed to load dead-drop detail.</p>';card.style.display='block';}
+}
+// ═══ BOTAWIKI TAB ═══
+async function pollBotawiki(){
+  if(activeTab!=='botawiki')return;
+  if(!meshGatewayUrl){
+    if(!meshConfigFetched){
+      try{
+        const cfg=await(await fetch('/dashboard/api/mesh')).json();
+        meshConfigFetched=true;
+        if(cfg.configured)meshGatewayUrl=cfg.gateway_url;
+      }catch(e){}
+    }
+    if(!meshGatewayUrl){
+      document.getElementById('botawiki-stats').innerHTML='<div class="card"><div class="stat status-warn">Not Configured</div><div class="stat-label">Gateway</div></div>';
+      document.getElementById('botawiki-claims-table').innerHTML='<p class="empty-state">No gateway configured.</p>';
+      return;
+    }
+  }
+  let allClaims=null;
+  try{allClaims=await(await fetch(meshGatewayUrl+'/botawiki/claims/all')).json();}catch(e){}
+  const statsDiv=document.getElementById('botawiki-stats');
+  const tableDiv=document.getElementById('botawiki-claims-table');
+  if(!allClaims||!allClaims.claims){
+    statsDiv.innerHTML='<div class="card"><div class="stat status-warn">Unreachable</div><div class="stat-label">Gateway</div></div>';
+    tableDiv.innerHTML='';return;
+  }
+  const claims=allClaims.claims;
+  const canonical=claims.filter(c=>c.status==='canonical').length;
+  const quarantine=claims.filter(c=>c.status==='quarantine').length;
+  const tombstoned=claims.filter(c=>c.status==='tombstoned').length;
+  let sc='<div class="card"><div class="stat">'+claims.length+'</div><div class="stat-label">Total Claims</div></div>';
+  sc+='<div class="card"><div class="stat status-ok">'+canonical+'</div><div class="stat-label">Canonical</div></div>';
+  sc+='<div class="card"><div class="stat status-warn">'+quarantine+'</div><div class="stat-label">Quarantine</div></div>';
+  sc+='<div class="card"><div class="stat">'+tombstoned+'</div><div class="stat-label">Tombstoned</div></div>';
+  statsDiv.innerHTML=sc;
+  if(claims.length===0){tableDiv.innerHTML='<p class="empty-state">No claims submitted yet.</p>';return;}
+  let h='<table class="dtable"><tr><th>ID</th><th>Namespace</th><th>Type</th><th>Status</th><th>Confidence</th><th>Votes</th><th>Submitted</th></tr>';
+  for(const c of claims){
+    const id=(c.id||'').substring(0,12)+'...';
+    const ct=typeof c.claim_type==='string'?c.claim_type:JSON.stringify(c.claim_type);
+    const statusClass=c.status==='canonical'?'badge-green':c.status==='quarantine'?'badge-yellow':c.status==='tombstoned'?'badge-red':'badge-gray';
+    const approves=c.votes?c.votes.filter(v=>v.approve).length:0;
+    const totalV=c.votes?c.votes.length:0;
+    h+='<tr class="screening-row" style="cursor:pointer" onclick="showBotawikiDetail(\''+esc(c.id)+'\')">';
+    h+='<td style="font-family:monospace;font-size:11px">'+esc(id)+'</td>';
+    h+='<td>'+esc(c.namespace)+'</td>';
+    h+='<td>'+esc(ct)+'</td>';
+    h+='<td><span class="badge '+statusClass+'">'+c.status+'</span></td>';
+    h+='<td>'+c.confidence_bp+' bp</td>';
+    h+='<td>'+approves+'/'+totalV+'</td>';
+    h+='<td style="font-size:12px">'+fmtTimeShort(c.submitted_at_ms)+'</td>';
+    h+='</tr>';
+  }
+  h+='</table>';
+  tableDiv.innerHTML=h;
+  window._botawikiClaims=claims;
+}
+function showBotawikiDetail(claimId){
+  const claims=window._botawikiClaims||[];
+  const c=claims.find(x=>x.id===claimId);
+  if(!c)return;
+  const card=document.getElementById('botawiki-detail-card');
+  const detail=document.getElementById('botawiki-detail');
+  let h='<span class="detail-back" onclick="document.getElementById(\'botawiki-detail-card\').style.display=\'none\'">← Close</span>';
+  h+='<div style="margin-top:12px;display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px">';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">ID</div><div style="font-family:monospace;font-size:10px;margin-top:4px;word-break:break-all">'+esc(c.id)+'</div></div>';
+  const ct=typeof c.claim_type==='string'?c.claim_type:JSON.stringify(c.claim_type);
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">TYPE</div><div style="font-size:14px;margin-top:4px">'+esc(ct)+'</div></div>';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">NAMESPACE</div><div style="font-size:13px;margin-top:4px">'+esc(c.namespace)+'</div></div>';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">ATTESTER</div><div style="font-family:monospace;font-size:11px;margin-top:4px">'+esc((c.attester_id||'').substring(0,16)+'...')+'</div></div>';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">CONFIDENCE</div><div style="font-size:18px;font-weight:600;margin-top:4px">'+c.confidence_bp+' bp</div></div>';
+  const statusClass=c.status==='canonical'?'badge-green':c.status==='quarantine'?'badge-yellow':'badge-red';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">STATUS</div><div style="margin-top:4px"><span class="badge '+statusClass+'">'+c.status+'</span></div></div>';
+  h+='<div style="padding:10px;background:#0d1117;border:1px solid #30363d;border-radius:6px"><div style="font-size:11px;color:#8b949e">SUBMITTED</div><div style="font-size:12px;margin-top:4px">'+fmtTime(c.submitted_at_ms)+'</div></div>';
+  h+='</div>';
+  h+='<div style="margin-top:16px;font-size:12px;color:#8b949e;margin-bottom:8px">PAYLOAD</div>';
+  h+='<div class="json-body">'+tryPrettyJson(JSON.stringify(c.payload))+'</div>';
+  if(c.votes&&c.votes.length>0){
+    h+='<div style="margin-top:16px;font-size:12px;color:#8b949e;margin-bottom:8px">VOTES ('+c.votes.length+')</div>';
+    h+='<table class="dtable"><tr><th>#</th><th>Validator</th><th>Decision</th><th>Time</th></tr>';
+    for(let i=0;i<c.votes.length;i++){
+      const v=c.votes[i];
+      const dec=v.approve?'<span class="badge badge-green">approve</span>':'<span class="badge badge-red">reject</span>';
+      h+='<tr><td>'+(i+1)+'</td><td style="font-family:monospace;font-size:11px">'+esc(v.validator_id)+'</td><td>'+dec+'</td><td>'+fmtTimeShort(v.ts_ms)+'</td></tr>';
+    }
+    h+='</table>';
+  }
+  detail.innerHTML=h;
+  card.style.display='block';
+}
 function schedule(fn,ms){fn().finally(()=>setTimeout(()=>schedule(fn,ms),ms));}
 schedule(poll,2000);
 schedule(fetchAlerts,5000);
 schedule(pollMesh,2000);
+schedule(pollBotawiki,2000);
 </script>
 </body>
 </html>"#;

--- a/cluster/gateway/src/botawiki.rs
+++ b/cluster/gateway/src/botawiki.rs
@@ -60,6 +60,21 @@ pub struct StoredClaim {
     pub submitted_at_ms: i64,
 }
 
+/// View struct for the full claim list endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct StoredClaimView {
+    pub id: Uuid,
+    pub claim_type: serde_json::Value,
+    pub namespace: String,
+    pub attester_id: String,
+    pub confidence_bp: u32,
+    pub status: ClaimStatus,
+    pub votes: Vec<Vote>,
+    pub validators: Vec<String>,
+    pub submitted_at_ms: i64,
+    pub payload: serde_json::Value,
+}
+
 /// In-memory Botawiki claim store.
 #[derive(Debug, Clone, Default)]
 pub struct BotawikiStore {
@@ -175,6 +190,26 @@ impl BotawikiStore {
             pending_votes,
             total,
         }
+    }
+
+    /// Return all stored claims with full metadata.
+    pub async fn list_all(&self) -> Vec<StoredClaimView> {
+        let claims = self.claims.read().await;
+        claims
+            .iter()
+            .map(|(id, sc)| StoredClaimView {
+                id: *id,
+                claim_type: serde_json::to_value(&sc.claim.claim_type).unwrap_or_default(),
+                namespace: sc.claim.namespace.clone(),
+                attester_id: sc.claim.attester_id.clone(),
+                confidence_bp: sc.claim.confidence_bp.value(),
+                status: sc.status.clone(),
+                votes: sc.votes.clone(),
+                validators: sc.validators.clone(),
+                submitted_at_ms: sc.submitted_at_ms,
+                payload: sc.claim.payload.clone(),
+            })
+            .collect()
     }
 
     /// Query canonical claims by namespace and optional claim_type.
@@ -337,6 +372,34 @@ mod tests {
         assert_eq!(summary.disputed, 0);
         assert_eq!(summary.total, 3);
         assert_eq!(summary.pending_votes.len(), 1); // only c3 is quarantined
+    }
+
+    #[tokio::test]
+    async fn list_all_returns_all_claims() {
+        let store = BotawikiStore::new();
+        let validators = vec!["v1".into(), "v2".into(), "v3".into()];
+
+        let c1 = sample_claim();
+        let id1 = c1.id;
+        store.submit(c1, validators.clone()).await;
+
+        let c2 = sample_claim();
+        let id2 = c2.id;
+        store.submit(c2, validators.clone()).await;
+        store.vote(&id2, "v1", true).await.unwrap();
+        store.vote(&id2, "v2", true).await.unwrap();
+
+        let all = store.list_all().await;
+        assert_eq!(all.len(), 2);
+
+        let q = all.iter().find(|c| c.id == id1).unwrap();
+        assert_eq!(q.status, ClaimStatus::Quarantine);
+        assert_eq!(q.namespace, "b/lore");
+        assert_eq!(q.confidence_bp, 8000);
+
+        let can = all.iter().find(|c| c.id == id2).unwrap();
+        assert_eq!(can.status, ClaimStatus::Canonical);
+        assert_eq!(can.votes.len(), 2);
     }
 
     #[tokio::test]

--- a/cluster/gateway/src/main.rs
+++ b/cluster/gateway/src/main.rs
@@ -19,7 +19,7 @@ use tracing::info;
 
 use aegis_gateway::auth;
 use aegis_gateway::botawiki::BotawikiStore;
-use aegis_gateway::mesh_routes::{self, RelayStats};
+use aegis_gateway::mesh_routes::{self, RelayLog, RelayStats};
 use aegis_gateway::nats_bridge::{NatsBridge, TrustmarkCache};
 use aegis_gateway::routes;
 use aegis_gateway::store::MemoryStore;
@@ -171,6 +171,7 @@ async fn main() {
     let dead_drop_store = Arc::new(DeadDropStore::new());
     let botawiki_store = Arc::new(BotawikiStore::new());
     let relay_stats = Arc::new(RelayStats::new());
+    let relay_log = Arc::new(RelayLog::new());
 
     // Replay protection (in-memory, inline cleanup)
     let replay_protection = Arc::new(auth::ReplayProtection::new());
@@ -202,18 +203,27 @@ async fn main() {
         .layer(Extension(wss_registry.clone()))
         .layer(Extension(dead_drop_store.clone()))
         .layer(Extension(botawiki_store.clone()))
-        .layer(Extension(relay_stats.clone()));
+        .layer(Extension(relay_stats.clone()))
+        .layer(Extension(relay_log.clone()));
 
     // Public mesh status routes (no auth required)
     let mesh_routes = Router::new()
         .route("/mesh/status", get(mesh_routes::mesh_status))
         .route("/mesh/peers", get(mesh_routes::mesh_peers))
+        .route("/mesh/peers/{bot_id}", get(mesh_routes::mesh_peer_detail))
         .route("/mesh/relay/stats", get(mesh_routes::mesh_relay_stats))
+        .route("/mesh/relay/log", get(mesh_routes::mesh_relay_log))
         .route("/mesh/claims", get(mesh_routes::mesh_claims))
         .route("/mesh/dead-drops", get(mesh_routes::mesh_dead_drops))
+        .route(
+            "/mesh/dead-drops/{bot_id}",
+            get(mesh_routes::mesh_dead_drop_detail),
+        )
+        .route("/botawiki/claims/all", get(mesh_routes::botawiki_list_all))
         .layer(Extension(wss_registry.clone()))
         .layer(Extension(trustmark_cache))
         .layer(Extension(relay_stats))
+        .layer(Extension(relay_log))
         .layer(Extension(botawiki_store))
         .layer(Extension(dead_drop_store));
 

--- a/cluster/gateway/src/mesh_routes.rs
+++ b/cluster/gateway/src/mesh_routes.rs
@@ -3,9 +3,12 @@
 //! Public endpoints (no auth required) that expose aggregate mesh metrics.
 //! These power the Dashboard "Mesh" tab and CLI `aegis mesh` commands.
 
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use serde::Serialize;
@@ -121,6 +124,99 @@ pub async fn mesh_dead_drops(
     Json(summary)
 }
 
+// ── Drill-down endpoints ──────────────────────────────────────────
+
+/// A single relay event for the log.
+#[derive(Debug, Clone, Serialize)]
+pub struct RelayEvent {
+    pub from: String,
+    pub to: String,
+    pub status: String, // "delivered", "dead_dropped", "quarantined"
+    pub msg_type: String,
+    pub ts_ms: i64,
+}
+
+/// Append-only relay log (last 100 events).
+#[derive(Debug, Default)]
+pub struct RelayLog {
+    events: std::sync::RwLock<VecDeque<RelayEvent>>,
+}
+
+impl RelayLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&self, event: RelayEvent) {
+        let mut events = self.events.write().unwrap();
+        events.push_back(event);
+        if events.len() > 100 {
+            events.pop_front();
+        }
+    }
+
+    pub fn recent(&self, limit: usize) -> Vec<RelayEvent> {
+        let events = self.events.read().unwrap();
+        events.iter().rev().take(limit).cloned().collect()
+    }
+}
+
+/// GET /mesh/peers/:bot_id — peer detail with TRUSTMARK dimensions and online status.
+pub async fn mesh_peer_detail(
+    Extension(trustmark_cache): Extension<Arc<TrustmarkCache>>,
+    Extension(wss_registry): Extension<Arc<WssConnectionRegistry>>,
+    Path(bot_id): Path<String>,
+) -> impl IntoResponse {
+    let online = wss_registry.is_online(&bot_id).await;
+    let score = trustmark_cache.get(&bot_id).await;
+    match score {
+        Some(cached) => Json(serde_json::json!({
+            "bot_id": bot_id,
+            "online": online,
+            "score_bp": cached.score_bp,
+            "dimensions": cached.dimensions,
+            "tier": cached.tier,
+            "computed_at_ms": cached.computed_at_ms,
+        }))
+        .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "bot not found"})),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /mesh/relay/log — recent relay events.
+pub async fn mesh_relay_log(
+    Extension(relay_log): Extension<Arc<RelayLog>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let limit = params
+        .get("limit")
+        .and_then(|l| l.parse().ok())
+        .unwrap_or(20);
+    let events = relay_log.recent(limit);
+    Json(serde_json::json!({ "events": events, "count": events.len() }))
+}
+
+/// GET /mesh/dead-drops/:bot_id — per-bot dead-drop detail.
+pub async fn mesh_dead_drop_detail(
+    Extension(dead_drop_store): Extension<Arc<DeadDropStore>>,
+    Path(bot_id): Path<String>,
+) -> impl IntoResponse {
+    let drops = dead_drop_store.get_for_bot(&bot_id).await;
+    Json(serde_json::json!({ "bot_id": bot_id, "drops": drops, "count": drops.len() }))
+}
+
+/// GET /botawiki/claims/all — full claim list with content.
+pub async fn botawiki_list_all(
+    Extension(botawiki_store): Extension<Arc<BotawikiStore>>,
+) -> impl IntoResponse {
+    let claims = botawiki_store.list_all().await;
+    Json(serde_json::json!({ "claims": claims, "count": claims.len() }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +256,56 @@ mod tests {
         let json = serde_json::to_string(&snap).unwrap();
         assert!(json.contains("\"sent\":10"));
         assert!(json.contains("\"dead_dropped\":3"));
+    }
+
+    #[test]
+    fn relay_log_push_and_recent() {
+        let log = RelayLog::new();
+        for i in 0..5 {
+            log.push(RelayEvent {
+                from: format!("bot_{i}"),
+                to: "target".into(),
+                status: "delivered".into(),
+                msg_type: "relay".into(),
+                ts_ms: 1700000000000 + i,
+            });
+        }
+        let recent = log.recent(3);
+        assert_eq!(recent.len(), 3);
+        // Most recent first
+        assert_eq!(recent[0].from, "bot_4");
+        assert_eq!(recent[2].from, "bot_2");
+    }
+
+    #[test]
+    fn relay_log_caps_at_100() {
+        let log = RelayLog::new();
+        for i in 0..120 {
+            log.push(RelayEvent {
+                from: format!("bot_{i}"),
+                to: "target".into(),
+                status: "delivered".into(),
+                msg_type: "relay".into(),
+                ts_ms: 1700000000000 + i,
+            });
+        }
+        let all = log.recent(200);
+        assert_eq!(all.len(), 100);
+        // Oldest remaining should be bot_20 (0..19 were evicted)
+        assert_eq!(all.last().unwrap().from, "bot_20");
+    }
+
+    #[test]
+    fn relay_event_serializes() {
+        let event = RelayEvent {
+            from: "sender".into(),
+            to: "receiver".into(),
+            status: "delivered".into(),
+            msg_type: "relay".into(),
+            ts_ms: 1700000000000,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"from\":\"sender\""));
+        assert!(json.contains("\"status\":\"delivered\""));
     }
 }

--- a/cluster/gateway/src/routes.rs
+++ b/cluster/gateway/src/routes.rs
@@ -26,7 +26,7 @@ use tokio::sync::RwLock;
 use crate::auth::VerifiedIdentity;
 use crate::botawiki::BotawikiStore;
 use crate::evaluator::EvaluatorService;
-use crate::mesh_routes::RelayStats;
+use crate::mesh_routes::{RelayEvent, RelayLog, RelayStats};
 use crate::nats_bridge::{NatsBridge, TrustmarkCache};
 use crate::store::{EvidenceRecord, EvidenceStore};
 use crate::ws::{DeadDropStore, RelayEnvelope, WssConnectionRegistry};
@@ -410,6 +410,7 @@ pub async fn mesh_send<S: EvidenceStore>(
     Extension(wss_registry): Extension<Arc<WssConnectionRegistry>>,
     Extension(dead_drop_store): Extension<Arc<DeadDropStore>>,
     Extension(relay_stats): Extension<Arc<RelayStats>>,
+    Extension(relay_log): Extension<Arc<RelayLog>>,
     Json(payload): Json<MeshSendRequest>,
 ) -> impl IntoResponse {
     // Validate request
@@ -503,6 +504,13 @@ pub async fn mesh_send<S: EvidenceStore>(
                         "mesh relay quarantined: injection detected in relay message"
                     );
                     relay_stats.quarantined.fetch_add(1, Ordering::Relaxed);
+                    relay_log.push(RelayEvent {
+                        from: identity.pubkey.clone(),
+                        to: payload.to.clone(),
+                        status: "quarantined".into(),
+                        msg_type: payload.msg_type.clone(),
+                        ts_ms: now_epoch_ms(),
+                    });
                     return (
                         StatusCode::FORBIDDEN,
                         Json(serde_json::json!({
@@ -536,6 +544,13 @@ pub async fn mesh_send<S: EvidenceStore>(
         let delivered = wss_registry.send_to(&payload.to, &envelope_json).await;
         if delivered {
             relay_stats.sent.fetch_add(1, Ordering::Relaxed);
+            relay_log.push(RelayEvent {
+                from: identity.pubkey.clone(),
+                to: payload.to.clone(),
+                status: "delivered".into(),
+                msg_type: payload.msg_type.clone(),
+                ts_ms: now_epoch_ms(),
+            });
             tracing::info!(
                 from = %identity.pubkey,
                 to = %payload.to,
@@ -562,6 +577,13 @@ pub async fn mesh_send<S: EvidenceStore>(
         {
             Ok(()) => {
                 relay_stats.dead_dropped.fetch_add(1, Ordering::Relaxed);
+                relay_log.push(RelayEvent {
+                    from: identity.pubkey.clone(),
+                    to: payload.to.clone(),
+                    status: "dead_dropped".into(),
+                    msg_type: payload.msg_type.clone(),
+                    ts_ms: now_epoch_ms(),
+                });
                 tracing::info!(
                     from = %identity.pubkey,
                     to = %payload.to,
@@ -1122,6 +1144,7 @@ mod tests {
             .layer(Extension(Arc::new(BotawikiRateLimiter::new())))
             .layer(Extension(evaluator_svc))
             .layer(Extension(Arc::new(RelayStats::new())))
+            .layer(Extension(Arc::new(RelayLog::new())))
             .layer(middleware::from_fn(auth::auth_middleware));
 
         Router::new().merge(authed)

--- a/cluster/gateway/src/ws.rs
+++ b/cluster/gateway/src/ws.rs
@@ -428,6 +428,16 @@ impl DeadDropStore {
         drops.values().map(|q| q.len()).sum()
     }
 
+    /// Return all non-expired dead-drops for a specific bot.
+    pub async fn get_for_bot(&self, bot_id: &str) -> Vec<DeadDrop> {
+        let drops = self.drops.read().await;
+        let now = now_epoch_ms();
+        drops
+            .get(bot_id)
+            .map(|q| q.iter().filter(|d| d.expires_ms > now).cloned().collect())
+            .unwrap_or_default()
+    }
+
     /// Return a summary of all dead-drop queues.
     pub async fn summary(&self) -> DeadDropSummary {
         let drops = self.drops.read().await;
@@ -780,6 +790,43 @@ mod tests {
             .find(|r| r.bot_id == "bot_b")
             .unwrap();
         assert_eq!(b.count, 1);
+    }
+
+    #[tokio::test]
+    async fn dead_drop_get_for_bot() {
+        let store = DeadDropStore::new();
+        store.store("bot_a", "x", "m1", "relay").await.unwrap();
+        store.store("bot_a", "y", "m2", "ping").await.unwrap();
+        store.store("bot_b", "x", "m3", "relay").await.unwrap();
+
+        let result = store.get_for_bot("bot_a").await;
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].body, "m1");
+        assert_eq!(result[1].body, "m2");
+
+        let result_b = store.get_for_bot("bot_b").await;
+        assert_eq!(result_b.len(), 1);
+
+        let result_c = store.get_for_bot("nonexistent").await;
+        assert_eq!(result_c.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn dead_drop_get_for_bot_skips_expired() {
+        let store = DeadDropStore::new();
+        store.store("bot_a", "x", "valid", "relay").await.unwrap();
+        store.store("bot_a", "y", "expired", "relay").await.unwrap();
+
+        // Expire the second message
+        {
+            let mut drops = store.drops.write().await;
+            let queue = drops.get_mut("bot_a").unwrap();
+            queue[1].expires_ms = now_epoch_ms() - 1000;
+        }
+
+        let result = store.get_for_bot("bot_a").await;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].body, "valid");
     }
 
     #[tokio::test]

--- a/cluster/gateway/tests/security_tests.rs
+++ b/cluster/gateway/tests/security_tests.rs
@@ -15,7 +15,7 @@ use tower::ServiceExt;
 use aegis_gateway::auth::{self, ReplayProtection, SigningInput, VerifiedIdentity};
 use aegis_gateway::botawiki::BotawikiStore;
 use aegis_gateway::evaluator::EvaluatorService;
-use aegis_gateway::mesh_routes::RelayStats;
+use aegis_gateway::mesh_routes::{RelayLog, RelayStats};
 use aegis_gateway::nats_bridge::{CachedScore, NatsBridge, TrustmarkCache};
 use aegis_gateway::rate_limit::TierRateLimiter;
 use aegis_gateway::routes;
@@ -96,6 +96,7 @@ fn security_test_app(
         .layer(Extension(Arc::new(routes::BotawikiRateLimiter::new())))
         .layer(Extension(Arc::new(EvaluatorService::new())))
         .layer(Extension(Arc::new(RelayStats::new())))
+        .layer(Extension(Arc::new(RelayLog::new())))
         .layer(middleware::from_fn(auth::auth_middleware))
         .layer(Extension(replay))
         .layer(Extension(rate_limiter))
@@ -658,6 +659,7 @@ async fn dead_drop_quota_enforced() {
         .layer(Extension(Arc::new(routes::BotawikiRateLimiter::new())))
         .layer(Extension(Arc::new(EvaluatorService::new())))
         .layer(Extension(Arc::new(RelayStats::new())))
+        .layer(Extension(Arc::new(RelayLog::new())))
         .layer(middleware::from_fn(auth::auth_middleware))
         .layer(Extension(Arc::new(ReplayProtection::new())))
         .layer(Extension(Arc::new(TierRateLimiter::new())))


### PR DESCRIPTION
## Summary

Complete mesh and Botawiki visibility overhaul (Issue #221):

### Gateway API (6 new endpoints)
- `GET /mesh/peers/:bot_id` — peer detail with TRUSTMARK dimensions
- `GET /mesh/relay/log?limit=N` — recent relay events with sender/recipient/status
- `GET /mesh/dead-drops/:bot_id` — per-bot dead-drop messages
- `GET /botawiki/claims/all` — full claim list with content, votes, validators
- CORS headers for dashboard cross-origin access
- WSS `/ws` route wired for bot WebSocket connections
- TRUSTMARK cache populated on GET compute (works without NATS)
- `RelayLog` (capped at 100 events) tracks all relay outcomes

### CLI (6 new commands)
- `aegis mesh peer <id>` — TRUSTMARK dimensions with bar charts
- `aegis mesh relay-log` — relay event table
- `aegis mesh dead-drop <id>` — per-bot queued messages
- `aegis botawiki list` — claims table with status/confidence/votes
- `aegis botawiki show <id>` — full detail with payload JSON + vote history
- `aegis botawiki search <ns>` — filter by namespace

### Dashboard (2 new features)
- **Botawiki tab** (12th) — claims table, click-to-expand detail panel with payload + votes
- **Mesh tab enhancements** — peer drill-down with TRUSTMARK bars, relay log with color-coded status, dead-drop drill-down

### E2E Test Results
- 3 bots authenticated via WSS (challenge-response)
- 36 evidence receipts accepted, TRUSTMARK 5278-5279bp (Tier 3)
- 5 relay messages delivered via WSS in real-time
- 1 injection attempt quarantined by heuristic engine
- 3 Botawiki claims submitted (quarantine, pending validator votes)
- All drill-down endpoints verified with live data
- Gateway lib tests: 114→120, new tests for RelayLog, list_all, get_for_bot

## Test plan
- [x] 120 gateway lib tests + 28 integration tests
- [x] 10 CLI tests
- [x] Full E2E: Gateway + 3 WSS bots + relay + injection + Botawiki
- [x] Dashboard Mesh + Botawiki tabs verified against live data

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)