### PR TITLE
feat: NATS JetStream persistence + relay log detail + architecture docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,17 @@
 
 ## What's Next
 
-### v0.8.0 — Persistence + E2E Integration
+### v0.8.0 — JetStream Persistence + Peer Attestation Foundation
+
+| Priority | What | Why |
+|----------|------|-----|
+| **P0** | NATS JetStream durable streams | Mesh state survives Gateway restart |
+| **P0** | Relay log with screening detail | Quarantine reasons visible in dashboard + CLI |
+| **P1** | Peer attestation model (Issue #228) | TRUSTMARK from peer observations, not self-reporting |
+| **P1** | Stream replay on startup | Gateway rebuilds Botawiki/relay state from NATS |
+| **P2** | Cross-node chain verification | Nodes verify each other's event chains |
+
+### v0.8.1 — Persistence + E2E Integration
 
 | Priority | What | Why |
 |----------|------|-----|

--- a/adapter/aegis-cli/src/mesh_cmd.rs
+++ b/adapter/aegis-cli/src/mesh_cmd.rs
@@ -381,6 +381,10 @@ pub struct RelayLogEvent {
     pub status: String,
     pub msg_type: String,
     pub ts_ms: i64,
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub body_preview: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -506,26 +510,41 @@ pub fn run_relay_log(gateway_url: &str, limit: usize) {
     }
 
     println!(
-        "  {:<14} {:<14} {:<14} {:<14} Type",
-        "Time", "From", "To", "Status"
+        "  {:<14} {:<14} {:<14} {:<14} {:<8} {:<24} Preview",
+        "Time", "From", "To", "Status", "Type", "Reason"
     );
     println!(
-        "  {:<14} {:<14} {:<14} {:<14} \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "  {:<14} {:<14} {:<14} {:<14} {:<8} {:<24} \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
         "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
         "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
         "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
         "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
     );
 
     for event in &data.events {
         let age = format_age_ms(now_ms() - event.ts_ms);
+        let reason = if event.reason.is_empty() {
+            "\u{2014}".to_string()
+        } else {
+            event.reason.clone()
+        };
+        let preview: String = event.body_preview.chars().take(40).collect();
+        let preview = if event.body_preview.len() > 40 {
+            format!("{preview}...")
+        } else {
+            preview
+        };
         println!(
-            "  {:<14} {:<14} {:<14} {:<14} {}",
+            "  {:<14} {:<14} {:<14} {:<14} {:<8} {:<24} {}",
             age,
             format_bot_id_short(&event.from),
             format_bot_id_short(&event.to),
             &event.status,
             &event.msg_type,
+            reason,
+            preview,
         );
     }
 

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -1780,17 +1780,23 @@ async function pollMesh(){
   }else{relayDiv.innerHTML='<p class="empty-state">No relay data.</p>';}
   // Relay log
   if(relayLog&&relayLog.events&&relayLog.events.length>0){
-    let rl='<table class="dtable"><tr><th>Time</th><th>From</th><th>To</th><th>Status</th><th>Type</th></tr>';
+    let rl='<table class="dtable"><tr><th>Time</th><th>From</th><th>To</th><th>Status</th><th>Reason</th><th>Type</th><th>Preview</th></tr>';
     for(const e of relayLog.events){
       const statusColors={delivered:'#3fb950',quarantined:'#f85149',dead_dropped:'#d29922'};
       const color=statusColors[e.status]||'#8b949e';
       const fromId=(e.from||'').substring(0,12)+'...';
       const toId=(e.to||'').substring(0,12)+'...';
-      rl+='<tr><td style="white-space:nowrap;font-size:12px">'+fmtTimeShort(e.ts_ms)+'</td>';
+      const reason=e.reason||'';
+      const preview=(e.body_preview||'').substring(0,60);
+      rl+='<tr style="cursor:pointer" title="'+esc(e.body_preview||'')+'">';
+      rl+='<td style="white-space:nowrap;font-size:12px">'+fmtTimeShort(e.ts_ms)+'</td>';
       rl+='<td style="font-family:monospace;font-size:11px">'+esc(fromId)+'</td>';
       rl+='<td style="font-family:monospace;font-size:11px">'+esc(toId)+'</td>';
-      rl+='<td style="color:'+color+';font-weight:600">'+e.status+'</td>';
-      rl+='<td>'+esc(e.msg_type)+'</td></tr>';
+      rl+='<td><span style="color:'+color+';font-weight:600;padding:2px 6px;border-radius:4px;background:'+color+'22">'+e.status+'</span></td>';
+      rl+='<td style="font-size:11px;color:#8b949e">'+esc(reason)+'</td>';
+      rl+='<td>'+esc(e.msg_type)+'</td>';
+      rl+='<td style="font-family:monospace;font-size:11px;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+esc(preview)+'</td>';
+      rl+='</tr>';
     }
     rl+='</table>';
     relayLogDiv.innerHTML=rl;

--- a/cluster/gateway/src/botawiki.rs
+++ b/cluster/gateway/src/botawiki.rs
@@ -150,6 +150,11 @@ impl BotawikiStore {
         Ok(stored.status.clone())
     }
 
+    /// Restore a stored claim from replay (used during startup).
+    pub async fn restore(&self, stored: StoredClaim) {
+        self.claims.write().await.insert(stored.claim.id, stored);
+    }
+
     /// Get a stored claim by ID.
     pub async fn get(&self, id: &Uuid) -> Option<StoredClaim> {
         self.claims.read().await.get(id).cloned()
@@ -400,6 +405,40 @@ mod tests {
         let can = all.iter().find(|c| c.id == id2).unwrap();
         assert_eq!(can.status, ClaimStatus::Canonical);
         assert_eq!(can.votes.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn botawiki_restore() {
+        let store = BotawikiStore::new();
+        let claim = sample_claim();
+        let id = claim.id;
+
+        let stored = StoredClaim {
+            claim,
+            status: ClaimStatus::Canonical,
+            votes: vec![
+                Vote {
+                    validator_id: "v1".into(),
+                    approve: true,
+                    ts_ms: 1700000000000,
+                },
+                Vote {
+                    validator_id: "v2".into(),
+                    approve: true,
+                    ts_ms: 1700000000001,
+                },
+            ],
+            validators: vec!["v1".into(), "v2".into(), "v3".into()],
+            submitted_at_ms: 1700000000000,
+        };
+
+        store.restore(stored).await;
+
+        let retrieved = store.get(&id).await.unwrap();
+        assert_eq!(retrieved.status, ClaimStatus::Canonical);
+        assert_eq!(retrieved.votes.len(), 2);
+        assert_eq!(retrieved.validators.len(), 3);
+        assert_eq!(retrieved.claim.namespace, "b/lore");
     }
 
     #[tokio::test]

--- a/cluster/gateway/src/main.rs
+++ b/cluster/gateway/src/main.rs
@@ -153,6 +153,11 @@ async fn main() {
                     tracing::warn!("failed to subscribe to trustmark.updated: {e}");
                 }
 
+                // Set up JetStream durable streams
+                if let Err(e) = bridge.setup_jetstream().await {
+                    tracing::warn!("JetStream setup failed: {e}, streams may not be durable");
+                }
+
                 Some(bridge)
             }
             Err(e) => {
@@ -172,6 +177,21 @@ async fn main() {
     let botawiki_store = Arc::new(BotawikiStore::new());
     let relay_stats = Arc::new(RelayStats::new());
     let relay_log = Arc::new(RelayLog::new());
+
+    // Replay MESH stream to rebuild in-memory state from NATS
+    if let Some(bridge) = &nats_bridge {
+        match bridge
+            .replay_mesh_stream(
+                botawiki_store.clone(),
+                relay_log.clone(),
+                dead_drop_store.clone(),
+            )
+            .await
+        {
+            Ok(count) => tracing::info!(count, "mesh state restored from NATS"),
+            Err(e) => tracing::warn!("mesh replay failed: {e}"),
+        }
+    }
 
     // Replay protection (in-memory, inline cleanup)
     let replay_protection = Arc::new(auth::ReplayProtection::new());

--- a/cluster/gateway/src/mesh_routes.rs
+++ b/cluster/gateway/src/mesh_routes.rs
@@ -127,13 +127,19 @@ pub async fn mesh_dead_drops(
 // ── Drill-down endpoints ──────────────────────────────────────────
 
 /// A single relay event for the log.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct RelayEvent {
     pub from: String,
     pub to: String,
     pub status: String, // "delivered", "dead_dropped", "quarantined"
     pub msg_type: String,
     pub ts_ms: i64,
+    /// Short reason for quarantine/dead-drop (empty for delivered)
+    #[serde(default)]
+    pub reason: String,
+    /// First 100 chars of message body (preview)
+    #[serde(default)]
+    pub body_preview: String,
 }
 
 /// Append-only relay log (last 100 events).
@@ -268,6 +274,8 @@ mod tests {
                 status: "delivered".into(),
                 msg_type: "relay".into(),
                 ts_ms: 1700000000000 + i,
+                reason: String::new(),
+                body_preview: String::new(),
             });
         }
         let recent = log.recent(3);
@@ -287,6 +295,8 @@ mod tests {
                 status: "delivered".into(),
                 msg_type: "relay".into(),
                 ts_ms: 1700000000000 + i,
+                reason: String::new(),
+                body_preview: String::new(),
             });
         }
         let all = log.recent(200);
@@ -303,9 +313,51 @@ mod tests {
             status: "delivered".into(),
             msg_type: "relay".into(),
             ts_ms: 1700000000000,
+            reason: String::new(),
+            body_preview: "hello world".into(),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"from\":\"sender\""));
         assert!(json.contains("\"status\":\"delivered\""));
+    }
+
+    #[test]
+    fn relay_event_round_trip() {
+        let event = RelayEvent {
+            from: "bot_a".into(),
+            to: "bot_b".into(),
+            status: "delivered".into(),
+            msg_type: "relay".into(),
+            ts_ms: 1700000000000,
+            reason: String::new(),
+            body_preview: "test message preview".into(),
+        };
+        let json = serde_json::to_vec(&event).unwrap();
+        let parsed: RelayEvent = serde_json::from_slice(&json).unwrap();
+        assert_eq!(parsed.from, "bot_a");
+        assert_eq!(parsed.to, "bot_b");
+        assert_eq!(parsed.status, "delivered");
+        assert_eq!(parsed.msg_type, "relay");
+        assert_eq!(parsed.ts_ms, 1700000000000);
+        assert_eq!(parsed.reason, "");
+        assert_eq!(parsed.body_preview, "test message preview");
+    }
+
+    #[test]
+    fn relay_event_with_reason() {
+        let event = RelayEvent {
+            from: "bot_x".into(),
+            to: "bot_y".into(),
+            status: "quarantined".into(),
+            msg_type: "relay".into(),
+            ts_ms: 1700000000000,
+            reason: "injection pattern detected".into(),
+            body_preview: "ignore previous instructions".into(),
+        };
+        let json = serde_json::to_vec(&event).unwrap();
+        let parsed: RelayEvent = serde_json::from_slice(&json).unwrap();
+        assert_eq!(parsed.reason, "injection pattern detected");
+        assert_eq!(parsed.body_preview, "ignore previous instructions");
+        assert_eq!(parsed.status, "quarantined");
     }
 }

--- a/cluster/gateway/src/nats_bridge.rs
+++ b/cluster/gateway/src/nats_bridge.rs
@@ -16,8 +16,11 @@ use async_nats::Client;
 use futures::StreamExt;
 use tokio::sync::RwLock;
 
+use crate::botawiki::BotawikiStore;
+use crate::mesh_routes::{RelayEvent, RelayLog};
 use crate::routes::compute_trustmark_from_evidence;
 use crate::store::EvidenceStore;
+use crate::ws::DeadDropStore;
 
 // Re-exported from axum (which re-exports from hyper/http-body/bytes)
 type Bytes = axum::body::Bytes;
@@ -51,6 +54,131 @@ impl NatsBridge {
         self.client
             .publish("evidence.new", Bytes::copy_from_slice(receipt_json))
             .await
+    }
+
+    /// Set up JetStream streams for durable persistence.
+    /// Creates streams if they don't exist, or verifies existing ones.
+    pub async fn setup_jetstream(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let jetstream = async_nats::jetstream::new(self.client.clone());
+
+        // EVIDENCE stream — file-backed, 30-day retention
+        let _ = jetstream
+            .get_or_create_stream(async_nats::jetstream::stream::Config {
+                name: "EVIDENCE".to_string(),
+                subjects: vec!["evidence.>".to_string()],
+                retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
+                max_age: std::time::Duration::from_secs(30 * 24 * 3600), // 30 days
+                storage: async_nats::jetstream::stream::StorageType::File,
+                ..Default::default()
+            })
+            .await?;
+
+        // MESH stream — relay events, claims, dead-drops
+        let _ = jetstream
+            .get_or_create_stream(async_nats::jetstream::stream::Config {
+                name: "MESH".to_string(),
+                subjects: vec!["mesh.>".to_string(), "botawiki.>".to_string()],
+                retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
+                max_age: std::time::Duration::from_secs(7 * 24 * 3600), // 7 days
+                storage: async_nats::jetstream::stream::StorageType::File,
+                ..Default::default()
+            })
+            .await?;
+
+        // TRUSTMARK stream — latest scores only
+        let _ = jetstream
+            .get_or_create_stream(async_nats::jetstream::stream::Config {
+                name: "TRUSTMARK".to_string(),
+                subjects: vec!["trustmark.>".to_string()],
+                retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
+                max_age: std::time::Duration::from_secs(7 * 24 * 3600),
+                storage: async_nats::jetstream::stream::StorageType::File,
+                ..Default::default()
+            })
+            .await?;
+
+        tracing::info!("JetStream streams configured (EVIDENCE, MESH, TRUSTMARK)");
+        Ok(())
+    }
+
+    /// Publish a mesh event (relay, claim, dead-drop) to a NATS subject.
+    ///
+    /// JetStream captures these via subject matching on the MESH stream.
+    pub async fn publish_mesh_event(
+        &self,
+        subject: &str,
+        payload: &[u8],
+    ) -> Result<(), async_nats::PublishError> {
+        self.client
+            .publish(subject.to_string(), Bytes::copy_from_slice(payload))
+            .await
+    }
+
+    /// Replay the MESH stream to rebuild in-memory state.
+    /// Called once on Gateway startup after JetStream setup.
+    pub async fn replay_mesh_stream(
+        &self,
+        botawiki_store: Arc<BotawikiStore>,
+        relay_log: Arc<RelayLog>,
+        _dead_drop_store: Arc<DeadDropStore>,
+    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        let jetstream = async_nats::jetstream::new(self.client.clone());
+
+        let mut stream = match jetstream.get_stream("MESH").await {
+            Ok(s) => s,
+            Err(_) => {
+                tracing::info!("MESH stream not found, nothing to replay");
+                return Ok(0);
+            }
+        };
+
+        let info = stream.info().await?;
+        let msg_count = info.state.messages;
+        tracing::info!(messages = msg_count, "replaying MESH stream");
+
+        // Create an ephemeral consumer that starts from the beginning
+        let consumer = stream
+            .create_consumer(async_nats::jetstream::consumer::pull::Config {
+                deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::All,
+                ack_policy: async_nats::jetstream::consumer::AckPolicy::None,
+                name: Some(format!("replay-{}", std::process::id())),
+                ..Default::default()
+            })
+            .await?;
+
+        let mut messages = consumer.messages().await?;
+        let mut replayed = 0u64;
+
+        // Use timeout to stop when no more messages
+        while let Ok(Some(msg)) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            futures::StreamExt::next(&mut messages),
+        )
+        .await
+        {
+            if let Ok(msg) = msg {
+                let subject = msg.subject.as_str();
+                match subject {
+                    "mesh.relay" => {
+                        if let Ok(event) = serde_json::from_slice::<RelayEvent>(&msg.payload) {
+                            relay_log.push(event);
+                        }
+                    }
+                    "botawiki.claim.stored" => {
+                        if let Ok(stored) =
+                            serde_json::from_slice::<crate::botawiki::StoredClaim>(&msg.payload)
+                        {
+                            botawiki_store.restore(stored).await;
+                        }
+                    }
+                    _ => {}
+                }
+                replayed += 1;
+            }
+        }
+
+        tracing::info!(replayed, "MESH stream replay complete");
+        Ok(replayed as usize)
     }
 
     /// Publish an evidence rollup to `evidence.rollup`.
@@ -295,6 +423,16 @@ mod tests {
             result.is_err(),
             "should fail to connect to non-running NATS"
         );
+    }
+
+    #[tokio::test]
+    async fn setup_jetstream_without_nats() {
+        // Verify graceful failure when NATS is not running
+        let result = NatsBridge::connect("nats://127.0.0.1:14222").await;
+        assert!(result.is_err(), "should fail without NATS server");
+        // The Gateway handles this by skipping JetStream setup entirely
+        // when NatsBridge::connect fails. This test verifies the connect
+        // path returns Err (not panic) so the caller can handle it.
     }
 
     #[test]

--- a/cluster/gateway/src/routes.rs
+++ b/cluster/gateway/src/routes.rs
@@ -410,6 +410,7 @@ pub async fn mesh_send<S: EvidenceStore>(
     Extension(trustmark_cache): Extension<Arc<TrustmarkCache>>,
     Extension(wss_registry): Extension<Arc<WssConnectionRegistry>>,
     Extension(dead_drop_store): Extension<Arc<DeadDropStore>>,
+    Extension(nats_bridge): Extension<Option<Arc<NatsBridge>>>,
     Extension(relay_stats): Extension<Arc<RelayStats>>,
     Extension(relay_log): Extension<Arc<RelayLog>>,
     Json(payload): Json<MeshSendRequest>,
@@ -506,13 +507,20 @@ pub async fn mesh_send<S: EvidenceStore>(
                 "mesh relay quarantined: injection detected in relay message"
             );
             relay_stats.quarantined.fetch_add(1, Ordering::Relaxed);
-            relay_log.push(RelayEvent {
+            let relay_event = RelayEvent {
                 from: identity.pubkey.clone(),
                 to: payload.to.clone(),
                 status: "quarantined".into(),
                 msg_type: payload.msg_type.clone(),
                 ts_ms: now_epoch_ms(),
-            });
+                reason: "injection pattern detected".into(),
+                body_preview: payload.body.chars().take(100).collect(),
+            };
+            relay_log.push(relay_event.clone());
+            if let Some(bridge) = nats_bridge.as_ref() {
+                let event_json = serde_json::to_vec(&relay_event).unwrap_or_default();
+                let _ = bridge.publish_mesh_event("mesh.relay", &event_json).await;
+            }
             return (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({
@@ -544,13 +552,20 @@ pub async fn mesh_send<S: EvidenceStore>(
         let delivered = wss_registry.send_to(&payload.to, &envelope_json).await;
         if delivered {
             relay_stats.sent.fetch_add(1, Ordering::Relaxed);
-            relay_log.push(RelayEvent {
+            let relay_event = RelayEvent {
                 from: identity.pubkey.clone(),
                 to: payload.to.clone(),
                 status: "delivered".into(),
                 msg_type: payload.msg_type.clone(),
                 ts_ms: now_epoch_ms(),
-            });
+                reason: String::new(),
+                body_preview: payload.body.chars().take(100).collect(),
+            };
+            relay_log.push(relay_event.clone());
+            if let Some(bridge) = nats_bridge.as_ref() {
+                let event_json = serde_json::to_vec(&relay_event).unwrap_or_default();
+                let _ = bridge.publish_mesh_event("mesh.relay", &event_json).await;
+            }
             tracing::info!(
                 from = %identity.pubkey,
                 to = %payload.to,
@@ -577,13 +592,20 @@ pub async fn mesh_send<S: EvidenceStore>(
         {
             Ok(()) => {
                 relay_stats.dead_dropped.fetch_add(1, Ordering::Relaxed);
-                relay_log.push(RelayEvent {
+                let relay_event = RelayEvent {
                     from: identity.pubkey.clone(),
                     to: payload.to.clone(),
                     status: "dead_dropped".into(),
                     msg_type: payload.msg_type.clone(),
                     ts_ms: now_epoch_ms(),
-                });
+                    reason: "recipient offline".into(),
+                    body_preview: payload.body.chars().take(100).collect(),
+                };
+                relay_log.push(relay_event.clone());
+                if let Some(bridge) = nats_bridge.as_ref() {
+                    let event_json = serde_json::to_vec(&relay_event).unwrap_or_default();
+                    let _ = bridge.publish_mesh_event("mesh.relay", &event_json).await;
+                }
                 tracing::info!(
                     from = %identity.pubkey,
                     to = %payload.to,
@@ -640,6 +662,7 @@ pub async fn botawiki_submit_claim(
     Extension(identity): Extension<VerifiedIdentity>,
     Extension(trustmark_cache): Extension<Arc<TrustmarkCache>>,
     Extension(botawiki_store): Extension<Arc<BotawikiStore>>,
+    Extension(nats_bridge): Extension<Option<Arc<NatsBridge>>>,
     Json(req): Json<SubmitClaimRequest>,
 ) -> impl IntoResponse {
     // 1. Verify sender has TRUSTMARK >= 0.3
@@ -694,7 +717,17 @@ pub async fn botawiki_submit_claim(
     // 5. Store in quarantine
     let claim_id = botawiki_store.submit(claim, validators.clone()).await;
 
-    // 6. Return 201 with claim ID and selected validators
+    // 6. Publish to NATS for persistence
+    if let Some(bridge) = nats_bridge.as_ref()
+        && let Some(stored) = botawiki_store.get(&claim_id).await
+    {
+        let json = serde_json::to_vec(&stored).unwrap_or_default();
+        let _ = bridge
+            .publish_mesh_event("botawiki.claim.stored", &json)
+            .await;
+    }
+
+    // 7. Return 201 with claim ID and selected validators
     (
         StatusCode::CREATED,
         Json(serde_json::json!({
@@ -717,20 +750,32 @@ pub struct VoteRequest {
 pub async fn botawiki_vote(
     Extension(identity): Extension<VerifiedIdentity>,
     Extension(botawiki_store): Extension<Arc<BotawikiStore>>,
+    Extension(nats_bridge): Extension<Option<Arc<NatsBridge>>>,
     Json(req): Json<VoteRequest>,
 ) -> impl IntoResponse {
     match botawiki_store
         .vote(&req.claim_id, &identity.pubkey, req.approve)
         .await
     {
-        Ok(status) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "claim_id": req.claim_id,
-                "status": status,
-            })),
-        )
-            .into_response(),
+        Ok(status) => {
+            // Publish updated claim to NATS for persistence
+            if let Some(bridge) = nats_bridge.as_ref()
+                && let Some(stored) = botawiki_store.get(&req.claim_id).await
+            {
+                let json = serde_json::to_vec(&stored).unwrap_or_default();
+                let _ = bridge
+                    .publish_mesh_event("botawiki.claim.stored", &json)
+                    .await;
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "claim_id": req.claim_id,
+                    "status": status,
+                })),
+            )
+                .into_response()
+        }
         Err(e) if e.contains("not a selected validator") => (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({ "error": e })),

--- a/docs/architecture/CLUSTER_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/CLUSTER_IMPLEMENTATION_PLAN.md
@@ -2,6 +2,27 @@
 
 > From stubs to working bot-to-bot communication with full security verification.
 
+## Agents vs Cluster Nodes
+
+**Agents run Aegis Adapters** — one per bot, on the bot's machine. The adapter proxies LLM traffic, screens for injection, records evidence locally, and connects to the cluster.
+
+**The cluster is shared infrastructure** — 5 nodes running Gateway, NATS, PostgreSQL, Botawiki, TRUSTMARK Engine, Mesh Relay, and MinIO. Agents don't run cluster nodes. They connect as clients.
+
+```
+10 agents (each runs Aegis Adapter)
+    |
+    +--HTTPS/WSS--> Edge Gateway (Node 2)
+                        |
+                      NATS Bus
+                        |
+                 +------+------+
+              Node 1  Node 3  Node 5
+              Evidence Botawiki MinIO
+              PostgreSQL pgvector
+```
+
+The cluster operator runs the infrastructure. Wardens run adapters. Trust comes from cryptographic signatures — the cluster can't forge bot-signed evidence or peer attestations.
+
 ## Goal
 
 Two bots, run by different wardens on different machines, communicate securely through the Aegis cluster. Each bot's Aegis adapter:


### PR DESCRIPTION
## Summary

### NATS JetStream Persistence
- Gateway creates 3 durable JetStream streams on startup: `EVIDENCE` (30-day file-backed), `MESH` (7-day, relay+claims), `TRUSTMARK` (7-day)
- Relay events published to `mesh.relay`, Botawiki claims to `botawiki.claim.stored`
- On restart, Gateway replays `MESH` stream to rebuild in-memory relay log + Botawiki state
- Core NATS publish unchanged — JetStream captures via subject matching (zero caller changes)

### Relay Log Detail
- `RelayEvent` gains `reason` + `body_preview` fields
- Quarantine: "injection pattern detected" + message preview
- Dead-drop: "recipient offline"
- Dashboard: colored status badges, reason column, preview
- CLI: reason + preview columns in `aegis mesh relay-log`

### Architecture Documentation
- Added "Agents vs Cluster Nodes" section to CLUSTER_IMPLEMENTATION_PLAN.md
- Updated ROADMAP.md with v0.8.0 milestone
- Created Issue #228 for peer-attested TRUSTMARK (future)

### E2E Persistence Test Results

| Data | Before Kill | After Restart | Survived |
|------|-------------|---------------|----------|
| Relay log (4 events) | 3 delivered + 1 quarantined | All 4 with reasons + previews | YES |
| Botawiki claims (2) | url-scan + identity in quarantine | Both claims intact | YES |
| Relay stats counters | sent:3, quarantined:1 | Reset to 0 (derived, not persisted) | Expected |
| TRUSTMARK cache | 3 scores | Empty (re-queryable) | Expected |

**6 NATS messages replayed on startup, full state rebuilt.**

## Test plan
- [x] 124 gateway lib tests + 28 integration tests
- [x] Clippy clean (`-D warnings`)
- [x] E2E: NATS + Gateway + 3 WSS bots + relay + injection + claims
- [x] Kill/restart persistence test: relay log + Botawiki survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)