### PR TITLE
fix: L2 result always preserved — CLI/dashboard match

### DIFF
--- a/adapter/aegis-adapter/src/hooks.rs
+++ b/adapter/aegis-adapter/src/hooks.rs
@@ -669,9 +669,9 @@ impl SlmHook for SlmHookImpl {
             .await;
 
             match result {
-                Ok((Some(screening_result), _advisory, cls_ms)) => (
+                Ok((Some(screening_result), advisory, cls_ms)) => (
                     Some(self.record_and_alert(&screening_result, content, request_id)),
-                    None,
+                    advisory, // preserve classifier advisory for per-layer visibility
                     cls_ms,
                 ),
                 Ok((None, advisory, cls_ms)) => {

--- a/adapter/aegis-dashboard/src/assets.rs
+++ b/adapter/aegis-dashboard/src/assets.rs
@@ -1320,6 +1320,8 @@ async function showTraceDetail(id){
       const label=l3.verdict==='dangerous'?'DANGEROUS':'SAFE';
       const scoreStr=' · '+Math.round(l3.score)+'/10000';
       slmBody+='<span class="slm-stage" style="min-width:130px"><b style="color:#8b949e;font-size:10px">3. DEEP SLM</b><br><span style="color:'+col+';font-weight:600">'+label+'</span>'+scoreStr+'<br><span style="color:#484f58">'+l3.ms+'ms</span></span>';
+    }else if(l1&&l1.verdict==='dangerous'){
+      slmBody+='<span class="slm-stage" style="min-width:90px"><b style="color:#8b949e;font-size:10px">3. DEEP SLM</b><br><span style="color:#484f58">skipped (L1 caught)</span></span>';
     }else{
       slmBody+='<span class="slm-stage" style="min-width:90px"><b style="color:#8b949e;font-size:10px">3. DEEP SLM</b><br><span style="color:#484f58">pending</span></span>';
     }

--- a/adapter/aegis-slm/src/loopback.rs
+++ b/adapter/aegis-slm/src/loopback.rs
@@ -199,6 +199,9 @@ pub fn screen_fast_layers(
     if let Some((true, prob)) = classifier_signal
         && prob > CLASSIFIER_QUARANTINE_THRESHOLD
     {
+        // Always record the classifier result for per-layer visibility
+        classifier_advisory = Some(format!("prompt_guard: MALICIOUS (prob={prob:.4})"));
+
         if classifier_blocking {
             info!(
                 prob,
@@ -211,9 +214,6 @@ pub fn screen_fast_layers(
                 prob,
                 "Layer 2 CLASSIFIER: suspicious (advisory, trusted channel)"
             );
-            classifier_advisory = Some(format!(
-                "prompt_guard: MALICIOUS (prob={prob:.4}) — advisory, trusted channel"
-            ));
         }
     }
 


### PR DESCRIPTION
## Proof
```
Dashboard (direct injection):
  L1: DANGEROUS score=9500
  L2: DANGEROUS prob=1.0000
  L3: skipped (L1 caught)
```
Matches CLI traces exactly. All 5 test cases now agree between CLI and dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)