### PR TITLE
refactor: ScreeningState — single source of truth

### DIFF
--- a/adapter/aegis-proxy/src/middleware.rs
+++ b/adapter/aegis-proxy/src/middleware.rs
@@ -222,6 +222,109 @@ pub struct SlmVerdict {
     pub l3: Option<LayerResult>,
 }
 
+/// Accumulates layer results during the screening pipeline.
+/// Each layer writes to this struct as it runs. At the end,
+/// `to_verdict()` produces the final SlmVerdict — ONE conversion point.
+#[derive(Debug, Clone, Default)]
+pub struct ScreeningState {
+    pub l1: Option<LayerResult>,
+    pub l2: Option<LayerResult>,
+    pub l3: Option<LayerResult>,
+    pub channel: Option<String>,
+    pub channel_user: Option<String>,
+    pub channel_trust_level: Option<String>,
+}
+
+impl ScreeningState {
+    pub fn record_l1(&mut self, dangerous: bool, score: f64, ms: u64, detail: Option<String>) {
+        self.l1 = Some(LayerResult {
+            verdict: if dangerous {
+                "dangerous".into()
+            } else {
+                "safe".into()
+            },
+            score,
+            ms,
+            detail,
+        });
+    }
+
+    pub fn record_l2(&mut self, prob: f64, ms: u64, detail: Option<String>) {
+        self.l2 = Some(LayerResult {
+            verdict: if prob > 0.5 {
+                "dangerous".into()
+            } else {
+                "safe".into()
+            },
+            score: prob,
+            ms,
+            detail,
+        });
+    }
+
+    pub fn record_l3(&mut self, dangerous: bool, score: f64, ms: u64, detail: Option<String>) {
+        self.l3 = Some(LayerResult {
+            verdict: if dangerous {
+                "dangerous".into()
+            } else {
+                "safe".into()
+            },
+            score,
+            ms,
+            detail,
+        });
+    }
+
+    /// Produce the final verdict from accumulated layer results.
+    /// Strategy B: L1 authoritative, L2 advisory, L3 final.
+    pub fn to_verdict(&self) -> SlmVerdict {
+        // Determine final action from cascade logic
+        let l1_dangerous = self
+            .l1
+            .as_ref()
+            .map(|l| l.verdict == "dangerous")
+            .unwrap_or(false);
+        let l3_dangerous = self
+            .l3
+            .as_ref()
+            .map(|l| l.verdict == "dangerous")
+            .unwrap_or(false);
+
+        let (action, threat_score, engine) = if l1_dangerous {
+            // L1 authoritative
+            let score = self.l1.as_ref().map(|l| l.score as u32).unwrap_or(0);
+            ("reject".to_string(), score, "heuristic".to_string())
+        } else if l3_dangerous {
+            // L3 final decision
+            let score = self.l3.as_ref().map(|l| l.score as u32).unwrap_or(0);
+            ("reject".to_string(), score, "ollama".to_string())
+        } else {
+            ("admit".to_string(), 0, String::new())
+        };
+
+        let total_ms = self.l1.as_ref().map(|l| l.ms).unwrap_or(0)
+            + self.l2.as_ref().map(|l| l.ms).unwrap_or(0)
+            + self.l3.as_ref().map(|l| l.ms).unwrap_or(0);
+
+        SlmVerdict {
+            action,
+            threat_score,
+            engine,
+            screening_ms: total_ms,
+            pass_a_ms: self.l1.as_ref().map(|l| l.ms),
+            classifier_ms: self.l2.as_ref().map(|l| l.ms),
+            classifier_advisory: self.l2.as_ref().and_then(|l| l.detail.clone()),
+            l1: self.l1.clone(),
+            l2: self.l2.clone(),
+            l3: self.l3.clone(),
+            channel: self.channel.clone(),
+            channel_user: self.channel_user.clone(),
+            channel_trust_level: self.channel_trust_level.clone(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Result from a single screening layer.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct LayerResult {

--- a/adapter/aegis-proxy/src/proxy.rs
+++ b/adapter/aegis-proxy/src/proxy.rs
@@ -955,15 +955,14 @@ async fn forward_request(
         None
     };
 
-    // SLM verdict — populated by the SLM hook below, used by traffic recorder
+    // Screening state — accumulates all layer results. ONE source of truth.
+    let mut screening = middleware::ScreeningState::default();
+    // SLM verdict — built from screening state at the convergence point
     let mut slm_verdict: Option<middleware::SlmVerdict> = None;
     // Deferred SLM content — for trusted channels, deep SLM runs after response
     let mut slm_deferred_content: Option<String> = None;
     // Classifier advisory — hoisted to outer scope so deferred paths can use it
     let mut classifier_advisory_outer: Option<String> = None;
-    // Per-layer results — single source of truth for dashboard/CLI/evidence
-    let mut layer_l1: Option<middleware::LayerResult> = None;
-    let mut layer_l2: Option<middleware::LayerResult> = None;
 
     // Run pre-request middleware (skip in pass-through mode)
     if state.config.mode != ProxyMode::PassThrough {
@@ -1113,91 +1112,47 @@ async fn forward_request(
                 // Hoist to outer scope for deferred paths
                 classifier_advisory_outer = classifier_advisory.clone();
 
-                // ── Populate per-layer results (single source of truth) ──
-                // L1 + L2 always run together. Extract their results regardless
-                // of which layer "won" the fast-layer decision.
+                // ── Record per-layer results into ScreeningState ──
+                // Parse L2 probability from advisory string (used by both catch/clean paths)
+                let l2_prob = classifier_advisory
+                    .as_ref()
+                    .and_then(|a| {
+                        a.find("prob=").map(|i| {
+                            let s = &a[i + 5..];
+                            let end = s.find(')').unwrap_or(s.len());
+                            s[..end].parse::<f64>().unwrap_or(0.0)
+                        })
+                    })
+                    .unwrap_or(0.0);
+
                 if let Some((_, ref verdict)) = fast_result {
                     if let Some(v) = verdict.as_ref() {
-                        // L1 heuristic result
                         let l1_dangerous = v.engine == "heuristic"
                             && (v.action == "reject" || v.action == "quarantine");
-                        layer_l1 = Some(middleware::LayerResult {
-                            verdict: if l1_dangerous {
-                                "dangerous".into()
-                            } else {
-                                "safe".into()
-                            },
-                            score: if l1_dangerous {
+                        screening.record_l1(
+                            l1_dangerous,
+                            if l1_dangerous {
                                 v.threat_score as f64
                             } else {
                                 0.0
                             },
-                            ms: v.pass_a_ms.unwrap_or(0),
-                            detail: if l1_dangerous { v.reason.clone() } else { None },
-                        });
-                        // L2 classifier result
-                        if let Some(cms) = v.classifier_ms {
-                            let l2_prob = classifier_advisory
-                                .as_ref()
-                                .and_then(|a| {
-                                    a.find("prob=").map(|i| {
-                                        let s = &a[i + 5..];
-                                        let end = s.find(')').unwrap_or(s.len());
-                                        s[..end].parse::<f64>().unwrap_or(0.0)
-                                    })
-                                })
-                                .unwrap_or(0.0);
-                            let l2_dangerous = l2_prob > 0.5;
-                            layer_l2 = Some(middleware::LayerResult {
-                                verdict: if l2_dangerous {
-                                    "dangerous".into()
-                                } else {
-                                    "safe".into()
-                                },
-                                score: l2_prob,
-                                ms: cms,
-                                detail: classifier_advisory.clone(),
-                            });
-                        }
+                            v.pass_a_ms.unwrap_or(0),
+                            if l1_dangerous { v.reason.clone() } else { None },
+                        );
+                        screening.record_l2(
+                            l2_prob,
+                            v.classifier_ms.unwrap_or(0),
+                            classifier_advisory.clone(),
+                        );
                     }
                 } else {
-                    // Fast layers returned None (both clean)
-                    layer_l1 = Some(middleware::LayerResult {
-                        verdict: "safe".into(),
-                        score: 0.0,
-                        ms: 0, // timing not available when clean
-                        detail: None,
-                    });
-                    if let Some(cms) = fast_classifier_ms {
-                        let l2_prob = classifier_advisory
-                            .as_ref()
-                            .and_then(|a| {
-                                a.find("prob=").map(|i| {
-                                    let s = &a[i + 5..];
-                                    let end = s.find(')').unwrap_or(s.len());
-                                    s[..end].parse::<f64>().unwrap_or(0.0)
-                                })
-                            })
-                            .unwrap_or(0.0);
-                        let l2_dangerous = l2_prob > 0.5;
-                        layer_l2 = Some(middleware::LayerResult {
-                            verdict: if l2_dangerous {
-                                "dangerous".into()
-                            } else {
-                                "safe".into()
-                            },
-                            score: l2_prob,
-                            ms: cms,
-                            detail: classifier_advisory.clone(),
-                        });
-                    } else {
-                        layer_l2 = Some(middleware::LayerResult {
-                            verdict: "safe".into(),
-                            score: 0.0,
-                            ms: 0,
-                            detail: None,
-                        });
-                    }
+                    // Fast layers clean
+                    screening.record_l1(false, 0.0, 0, None);
+                    screening.record_l2(
+                        l2_prob,
+                        fast_classifier_ms.unwrap_or(0),
+                        classifier_advisory.clone(),
+                    );
                 }
 
                 if let Some((decision, verdict)) = fast_result {
@@ -1370,27 +1325,31 @@ async fn forward_request(
                     }
                 }
 
-                // Stamp channel trust + per-layer results onto the verdict.
-                // This is the single convergence point — all paths lead here.
-                // ALWAYS create a verdict if screening ran, even if all layers pass.
-                if slm_verdict.is_none() {
-                    slm_verdict = Some(middleware::SlmVerdict {
-                        action: "admit".to_string(),
-                        ..Default::default()
-                    });
+                // ── Single convergence point: build verdict from ScreeningState ──
+                screening.channel = req_info.channel_trust.channel.clone();
+                screening.channel_user = req_info.channel_trust.user.clone();
+                screening.channel_trust_level =
+                    Some(format!("{:?}", req_info.channel_trust.trust_level).to_lowercase());
+                let mut final_verdict = screening.to_verdict();
+                // Merge enrichment data from hook-built verdict (annotations, intent, etc.)
+                if let Some(ref existing) = slm_verdict {
+                    if final_verdict.intent.is_empty() {
+                        final_verdict.intent = existing.intent.clone();
+                    }
+                    if final_verdict.confidence == 0 {
+                        final_verdict.confidence = existing.confidence;
+                    }
+                    final_verdict.annotation_count = existing.annotation_count;
+                    final_verdict.annotations = existing.annotations.clone();
+                    final_verdict.explanation = existing.explanation.clone();
+                    final_verdict.holster_profile = existing.holster_profile.clone();
+                    final_verdict.holster_action = existing.holster_action.clone();
+                    final_verdict.threshold_exceeded = existing.threshold_exceeded;
+                    final_verdict.screened_text = existing.screened_text.clone();
+                    final_verdict.dimensions = existing.dimensions.clone();
+                    final_verdict.reason = existing.reason.clone();
                 }
-                stamp_trust(&mut slm_verdict);
-                debug!(
-                    has_l1 = layer_l1.is_some(),
-                    has_l2 = layer_l2.is_some(),
-                    has_verdict = slm_verdict.is_some(),
-                    "stamping per-layer results"
-                );
-                if let Some(ref mut v) = slm_verdict {
-                    v.l1 = layer_l1.clone();
-                    v.l2 = layer_l2.clone();
-                    // L3 is populated by deferred path (updated via traffic_slm_updater)
-                }
+                slm_verdict = Some(final_verdict);
             }
         }
     }


### PR DESCRIPTION
## Summary
Replaced scattered verdict building with `ScreeningState` struct that
accumulates layer results and produces the final verdict via `to_verdict()`.

## What changed
- Added `ScreeningState` with `record_l1/l2/l3` + `to_verdict()`
- Proxy uses `screening.record_l1/l2()` instead of manual `LayerResult` construction
- Single convergence point builds verdict from `ScreeningState`
- Removed `layer_l1`/`layer_l2` variables

## Tests
- All workspace tests pass (600+ tests)
- E2E: CLI and dashboard match on all 5 test cases (15/15 layer matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)