### PR TITLE
fix(dashboard,proxy): Chat Completions SSE parser + 512KB capture limit

### DIFF
--- a/adapter/aegis-dashboard/src/routes.rs
+++ b/adapter/aegis-dashboard/src/routes.rs
@@ -1173,21 +1173,42 @@ fn parse_sse_response_text(sse_body: &str) -> Option<String> {
         }
     }
 
-    // Second pass: reassemble from delta events (if response.completed was truncated)
+    // Second pass: reassemble from delta events
+    // Supports both Responses API (`response.output_text.delta`) and
+    // Chat Completions (`choices[].delta.content`) SSE formats.
     let mut text = String::new();
     for line in sse_body.lines() {
         let data = match line
             .strip_prefix("data: ")
             .or_else(|| line.strip_prefix("data:"))
         {
-            Some(d) => d,
+            Some(d) => d.trim(),
             None => continue,
         };
-        if let Ok(evt) = serde_json::from_str::<serde_json::Value>(data)
-            && evt.get("type").and_then(|t| t.as_str()) == Some("response.output_text.delta")
+        if data == "[DONE]" {
+            continue;
+        }
+        let Ok(evt) = serde_json::from_str::<serde_json::Value>(data) else {
+            continue;
+        };
+        // Responses API: response.output_text.delta
+        if evt.get("type").and_then(|t| t.as_str()) == Some("response.output_text.delta")
             && let Some(delta) = evt.get("delta").and_then(|d| d.as_str())
         {
             text.push_str(delta);
+            continue;
+        }
+        // Chat Completions SSE: {"choices":[{"delta":{"content":"token"}}]}
+        if let Some(choices) = evt.get("choices").and_then(|c| c.as_array()) {
+            for choice in choices {
+                if let Some(content) = choice
+                    .get("delta")
+                    .and_then(|d| d.get("content"))
+                    .and_then(|c| c.as_str())
+                {
+                    text.push_str(content);
+                }
+            }
         }
     }
 
@@ -1419,4 +1440,33 @@ async fn api_mesh(State(state): State<Arc<DashboardSharedState>>) -> Json<serde_
         "gateway_url": state.gateway_url,
         "configured": state.gateway_url.is_some(),
     }))
+}
+
+#[cfg(test)]
+mod sse_parser_tests {
+    use super::parse_sse_response_text;
+
+    #[test]
+    fn chat_completions_delta_content_reassembled() {
+        let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\
+                   data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\
+                   data: [DONE]\n";
+        assert_eq!(
+            parse_sse_response_text(sse),
+            Some("Hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn responses_api_delta_still_works() {
+        let sse = "data: {\"type\":\"response.output_text.delta\",\"delta\":\"abc\"}\n\
+                   data: {\"type\":\"response.output_text.delta\",\"delta\":\"def\"}\n";
+        assert_eq!(parse_sse_response_text(sse), Some("abcdef".to_string()));
+    }
+
+    #[test]
+    fn empty_stream_returns_none() {
+        assert_eq!(parse_sse_response_text(""), None);
+        assert_eq!(parse_sse_response_text("data: [DONE]\n"), None);
+    }
 }

--- a/adapter/aegis-proxy/src/proxy.rs
+++ b/adapter/aegis-proxy/src/proxy.rs
@@ -1549,7 +1549,7 @@ async fn forward_request(
             let mut total: usize = 0;
             let mut stream = std::pin::pin!(byte_stream);
             let mut accumulated = Vec::new();
-            let capture_limit = 256 * 1024usize; // 256KB capture limit for traffic
+            let capture_limit = 512 * 1024usize; // 512KB: fits OpenClaw system prompts without truncating JSON
             // Accumulate streamed text for vault scanning.
             // We collect text_delta content across chunks and scan periodically.
             let mut text_buffer = String::new();


### PR DESCRIPTION
## Summary

Salvaged two fixes from the stale PR #163 after triage showed the rest of that PR was superseded by the ScreeningState / SlmVerdict refactors on main (see close comment on #163 for full triage table).

- **Chat Completions SSE reassembly.** Dashboard's `parse_sse_response_text` now handles `choices[].delta.content` events in addition to the existing Responses API (`response.output_text.delta`). Adds `[DONE]` sentinel handling. Previously Chat Completions streaming responses rendered blank in the dashboard traffic detail.
- **Proxy capture limit 256KB → 512KB.** OpenClaw system prompts routinely exceed 256KB, which truncated JSON mid-message and caused user messages to go missing in the dashboard. 512KB fits them without truncation.

## Scope

- `adapter/aegis-dashboard/src/routes.rs` — Chat Completions SSE branch in `parse_sse_response_text` + 3 unit tests
- `adapter/aegis-proxy/src/proxy.rs` — single-line constant bump

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] Workspace clippy clean under CI flags (`-D warnings` + standard allows)
- [x] `cargo test -p aegis-dashboard -p aegis-proxy` — 137 tests pass including 3 new SSE parser tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)