### PR TITLE
fix(gateway): wire BotawikiRateLimiter Extension in main router

### DIFF
--- a/cluster/gateway/src/main.rs
+++ b/cluster/gateway/src/main.rs
@@ -354,6 +354,7 @@ async fn main() {
         .layer(Extension(wss_registry.clone()))
         .layer(Extension(dead_drop_store.clone()))
         .layer(Extension(botawiki_store.clone()))
+        .layer(Extension(Arc::new(routes::BotawikiRateLimiter::new())))
         .layer(Extension(relay_stats.clone()))
         .layer(Extension(relay_log.clone()));
 


### PR DESCRIPTION
## Summary

`GET /botawiki/query` returned HTTP 500 on the standalone gateway binary because `cluster/gateway/src/main.rs` was missing the `BotawikiRateLimiter` Extension that the handler requires.

```
Missing request extension: Extension of type
  alloc::sync::Arc<aegis_gateway::routes::BotawikiRateLimiter>
  was not found.
```

The embedded-mode router already wires this layer (`cluster/gateway/src/routes.rs:1242`). This PR brings the standalone path in line.

## Reproduction
1. Start `aegis-gateway --embedded` with NATS.
2. Bootstrap an NC-Ed25519 identity with >= 0.3 TRUSTMARK.
3. `GET /botawiki/query` — returns 500 on main, returns 200 with this fix.

## Test plan
- [x] `cargo build --release -p aegis-gateway`
- [x] `cargo clippy -p aegis-gateway` clean under CI flags
- [x] `cargo test -p aegis-gateway --lib` — 115 tests pass
- [x] Restarted live gateway and re-verified signed `/botawiki/query` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)