### PR TITLE
fix(gateway): idempotent MemoryStore.insert_batch — unblocks adapter evidence push

### DIFF
--- a/cluster/gateway/src/store.rs
+++ b/cluster/gateway/src/store.rs
@@ -81,16 +81,22 @@ impl EvidenceStore for MemoryStore {
     }
 
     async fn insert_batch(&self, records: Vec<EvidenceRecord>) -> Result<usize, String> {
+        // Evidence is an append-only log with deterministic receipt IDs.
+        // A repeat of the same ID is a no-op, not an error — the adapter re-
+        // pushes from seq 1 after a restart, so aborting the batch on the
+        // first duplicate stalls the push loop forever. Skip duplicates and
+        // return the count of newly inserted records instead.
         let mut store = self.records.write().await;
-        let count = records.len();
+        let mut inserted = 0usize;
         for record in records {
             let id = record.id.clone();
             if store.contains_key(&id) {
-                return Err(format!("duplicate receipt id: {id}"));
+                continue;
             }
             store.insert(id, record);
+            inserted += 1;
         }
-        Ok(count)
+        Ok(inserted)
     }
 
     async fn count_for_bot(&self, bot_fingerprint: &str) -> Result<u64, String> {
@@ -111,5 +117,51 @@ impl EvidenceStore for MemoryStore {
             .collect();
         records.sort_by_key(|r| r.seq);
         Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str, seq: i64) -> EvidenceRecord {
+        EvidenceRecord {
+            id: id.to_string(),
+            bot_fingerprint: "test-bot".to_string(),
+            seq,
+            receipt_type: "ApiCall".to_string(),
+            ts_ms: 1_000_000 + seq,
+            core_json: "{}".to_string(),
+            receipt_hash: "h".to_string(),
+            request_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_batch_skips_duplicates_and_reports_new_inserts() {
+        let store = MemoryStore::new();
+
+        let first = store
+            .insert_batch(vec![rec("a", 1), rec("b", 2)])
+            .await
+            .unwrap();
+        assert_eq!(first, 2);
+
+        // Re-push an overlapping batch (a is duplicate, c is new)
+        let second = store
+            .insert_batch(vec![rec("a", 1), rec("c", 3)])
+            .await
+            .unwrap();
+        assert_eq!(second, 1, "only the new record should count");
+
+        assert_eq!(store.count_for_bot("test-bot").await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn insert_batch_full_duplicate_batch_is_zero_not_error() {
+        let store = MemoryStore::new();
+        store.insert_batch(vec![rec("a", 1)]).await.unwrap();
+        let repeat = store.insert_batch(vec![rec("a", 1)]).await.unwrap();
+        assert_eq!(repeat, 0);
     }
 }


### PR DESCRIPTION
## Problem

The adapter's gateway evidence-push task (`gateway_client.rs:232`) starts every session with `last_pushed_seq=0` and tries to push receipts in ascending batches. The gateway's `MemoryStore::insert_batch` aborted the whole batch on the first duplicate receipt ID, so after a single adapter restart the push task got stuck retrying seq 1..100 forever — never advancing its cursor.

Live reproduction (this repo, before fix):
```
INFO  automatic Merkle rollup completed seq=57654
WARN  gateway push failed: gateway returned 500 Internal Server Error:
      {"error":"duplicate receipt id: 019ce4dd-59b9-7d92-a4d1-2c6beea9965f"}
```
Same receipt, every 30 seconds, for 17+ minutes.

## Fix

Evidence is an append-only log with deterministic receipt IDs — a repeat ID means the exact same receipt, not a conflicting one. `insert_batch` now skips duplicates and returns the count of newly-inserted records instead of erroring.

`insert()` (single) keeps its strict duplicate-error behaviour; only the batch path changes.

## Live verification
After deploying the fix to the running gateway, the adapter recovered immediately and streamed ~22,000 backlogged receipts in ~3 minutes:
```
INFO  evidence batch pushed to gateway count=100
INFO  evidence batch pushed to gateway count=100
...
WARN  gateway push failed: gateway returned 429 Too Many Requests
      {"error":"rate limit exceeded","retry_after":0.4}
```
The 429 is the tier rate limiter doing its job — correct backpressure.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p aegis-gateway` clean under CI flags
- [x] `cargo test -p aegis-gateway --lib` — 117 pass (115 existing + 2 new)
  - `insert_batch_skips_duplicates_and_reports_new_inserts`
  - `insert_batch_full_duplicate_batch_is_zero_not_error`
- [x] Live end-to-end recovery verified on local gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)