### PR TITLE
fix(gateway): publish each batched receipt to NATS evidence.new (#280)

### DIFF
--- a/cluster/gateway/src/routes.rs
+++ b/cluster/gateway/src/routes.rs
@@ -182,6 +182,7 @@ pub async fn post_evidence<S: EvidenceStore>(
 pub async fn post_evidence_batch<S: EvidenceStore>(
     Extension(identity): Extension<VerifiedIdentity>,
     Extension(store): Extension<S>,
+    Extension(nats_bridge): Extension<Option<Arc<NatsBridge>>>,
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
     // Check body size
@@ -272,17 +273,46 @@ pub async fn post_evidence_batch<S: EvidenceStore>(
         }
     }
 
+    // Serialize records for NATS publish BEFORE insert consumes them.
+    // Publishing is essential: `run_trustmark_engine` subscribes to
+    // `evidence.new` and is the only path by which the gateway's TRUSTMARK
+    // cache gets recomputed from actual evidence. Without this publish the
+    // cache stays on the provisional 3500bp WSS-auth placeholder forever.
+    let record_jsons: Vec<Vec<u8>> = records
+        .iter()
+        .map(|r| serde_json::to_vec(r).unwrap_or_default())
+        .collect();
+
     // Batch insert
-    match store.insert_batch(records).await {
-        Ok(count) => (
-            StatusCode::CREATED,
-            Json(serde_json::json!({ "count": count })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e })),
-        ),
+    let count = match store.insert_batch(records).await {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            );
+        }
+    };
+
+    // Fan out each record to NATS `evidence.new` so the TRUSTMARK Engine,
+    // JetStream EVIDENCE stream, and any other downstream consumers see
+    // the same stream of updates whether the adapter used /evidence or
+    // /evidence/batch.
+    if let Some(bridge) = nats_bridge.as_ref() {
+        for record_json in &record_jsons {
+            if record_json.is_empty() {
+                continue;
+            }
+            if let Err(e) = bridge.publish_evidence(record_json).await {
+                tracing::warn!(error = %e, "failed to publish batched evidence to NATS");
+            }
+        }
     }
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "count": count })),
+    )
 }
 
 /// Compute a basic TRUSTMARK score from cluster-stored evidence.


### PR DESCRIPTION
Closes #280.

## Problem

\`post_evidence_batch\` was dropping the NATS hand-off entirely. Only the single-receipt \`post_evidence\` handler published to \`evidence.new\`, while adapters exclusively use \`/evidence/batch\` (\`gateway_client.rs\` pushes 100 receipts every 30s). The \`run_trustmark_engine\` subscriber therefore never saw any receipts, the engine never recomputed, and the gateway's \`TrustmarkCache\` stayed on the provisional 3500bp WSS-auth placeholder indefinitely — even for bots with tens of thousands of stored receipts.

## Fix

- Add \`Extension<Option<Arc<NatsBridge>>>\` to \`post_evidence_batch\`.
- Serialize each record before \`insert_batch\` consumes them.
- After successful insert, fan out each record to \`evidence.new\` fire-and-forget — same pattern \`post_evidence\` already uses.

## Live verification

Running against the full stack (NATS + \`aegis-gateway --embedded\` + real \`aegis\` adapter):

\`\`\`
Before fix:  score_bp=3500  dimensions all zero   (WSS-auth provisional)
After fix:   score_bp=5050
             chain_integrity    = 10000  (monotonic chain, no gaps)
             temporal_consistency = 2000  (real interval signal)
             relay_reliability  =  5000
             vault_hygiene      =  5000
             persona_integrity  =  5000
             tier=tier3
\`\`\`

Within ~10s of restart, the gateway picked up accumulated receipts from the adapter's push loop and the engine produced a real score.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace\` clean under CI flags
- [x] \`cargo test -p aegis-gateway\` — 159 tests pass
- [x] Live end-to-end — TRUSTMARK cache moves off 3500bp to an evidence-derived score
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)